### PR TITLE
Explicitly mark objects of structured type with base class data

### DIFF
--- a/PlaygroundLogger/Documentation/LoggerFormat.md
+++ b/PlaygroundLogger/Documentation/LoggerFormat.md
@@ -154,9 +154,11 @@ A `structured` log entry contains:
 * A `number` that specifies the number of elements contained within the
   structured object **that are contained in the log** (stored-count).
 
-  Due to the presence of gap elements, consumers are encouraged to avoid making deductions based on the relationship between `total-count` and `stored-count`.
-  
-  One exception is that the logger itself will, if the `total-count` field happens to be zero, not emit the `stored-count` field. It is then safe to assume that `total-count == 0 ==> stored-count == 0`. The rationale should be obvious.
+* A `bool` that specifies whether the first child vended is a base class object. This field is always `false` for log entries for non-`class` kinds (base-class).
+
+  If this field is `true`, consumers should assume that the first child element is going to be the base class data for the current object, and will be named `super`. The reverse deduction is strongly discouraged. 
+
+As an optiimization, if the `total-count` field happens to be zero, neither `stored-count` nor `base-class` will be emitted. It is then safe to assume that `total-count == 0 ==> stored-count == 0 ==> base-class == false`. The rationale should be obvious.
 
 Following this specification, there are as many log entries as specified to be
 contained in the log. Each of them follows the general format of a log entry,

--- a/PlaygroundLogger/PlaygroundLogger/LoggerDecoderImpl.swift
+++ b/PlaygroundLogger/PlaygroundLogger/LoggerDecoderImpl.swift
@@ -36,15 +36,17 @@ class PlaygroundDecodedObject_Structured: PlaygroundDecodedObject {
     let totalCount: UInt64
     let storedCount: UInt64
     let type: String
+    let hasSuperclass: Bool
     var children: [PlaygroundDecodedObject]
 
-    init (_ name: String, _ brief: String, _ long: String, _ total: UInt64, _ stored: UInt64, _ type: String) {
+    init (_ name: String, _ brief: String, _ long: String, _ total: UInt64, _ stored: UInt64, _ type: String, _ superclass: Bool) {
         self.typeName = brief
         self.summary = long
         self.totalCount = total
         self.storedCount = stored
         self.children = [PlaygroundDecodedObject]()
         self.type = type
+        self.hasSuperclass = superclass
         super.init(name)
     }
 
@@ -76,7 +78,8 @@ class PlaygroundObjectDecoder_Structured: PlaygroundObjectDecoder {
         guard let long = String(storage: bytes) else { return nil }
         guard let total = UInt64(storage: bytes) else { return nil }
         guard let stored: UInt64 = ((total > 0) ? UInt64(storage: bytes) : 0) else { return nil }
-        let object = PlaygroundDecodedObject_Structured(name, brief, long, total, stored, kind.description)
+        guard let superclass = ((total > 0) ? Bool(storage: bytes) : false) else { return nil }
+        let object = PlaygroundDecodedObject_Structured(name, brief, long, total, stored, kind.description, superclass)
         stored.doFor {
             object.addChild(decoder.decodeObject(bytes)!)
         }

--- a/PlaygroundLogger/PlaygroundLogger/LoggerMirror.swift
+++ b/PlaygroundLogger/PlaygroundLogger/LoggerMirror.swift
@@ -21,6 +21,7 @@ final class LoggerMirror {
     private var typeNameData: String?
     private var displayTypeNameData: String?
     private var quickLookData: PlaygroundQuickLook?? = nil
+    private var isSuperclassMirror: Bool = false
     
     private static let Swift_Stdlib_Regex = Regex(pattern: "(?<!\\.)\\b(Swift\\.)")
     
@@ -34,18 +35,20 @@ final class LoggerMirror {
         self.superclassMirror = (false,nil)
     }
     
-    private init(object x: Any, label: String?) {
+    private init(object x: Any, label: String?, isSuperclass: Bool = false) {
         self.object = x
         self.mirror = Mirror(reflecting: x)
         self.text = label
         self.superclassMirror = (false,nil)
+        self.isSuperclassMirror = isSuperclass
     }
 
-    private init(mirror x: Mirror, _ label: String?) {
+    private init(mirror x: Mirror, _ label: String?, isSuperclass: Bool = false) {
         self.object = nil
         self.mirror = x
         self.text = label
         self.superclassMirror = (false,nil)
+        self.isSuperclassMirror = isSuperclass
     }
     
     var count: Int {
@@ -57,7 +60,7 @@ final class LoggerMirror {
     var superclass: LoggerMirror? {
         if !self.superclassMirror.0 {
             if let sm = self.mirror.superclassMirror {
-                self.superclassMirror.1 = LoggerMirror(mirror: sm, "super")
+                self.superclassMirror.1 = LoggerMirror(mirror: sm, "super", isSuperclass: true)
             }
             self.superclassMirror.0 = true
         }
@@ -92,6 +95,10 @@ final class LoggerMirror {
             typeNameData = _typeName(valueType)
         }
         return typeNameData ?? ""
+    }
+    
+    var isSuperclass: Bool {
+        return isSuperclassMirror
     }
     
     var displayTypeName: String {

--- a/PlaygroundLogger/PlaygroundLogger/PlaygroundWriter.swift
+++ b/PlaygroundLogger/PlaygroundLogger/PlaygroundWriter.swift
@@ -16,7 +16,7 @@ class PlaygroundWriter {
     // this is the version of the PlaygroundLogger protocol
     // this needs to be changed if anyhthing in the encoding changes
     // in such a way that it would break existing consumers
-    static let version : UInt8 = 10
+    static let version : UInt8 = 11
     
     init() {
         stream = BytesStream()

--- a/PlaygroundLogger/PlaygroundLogger/TestCases.swift
+++ b/PlaygroundLogger/PlaygroundLogger/TestCases.swift
@@ -33,7 +33,7 @@ class VersionDecodingTestCase : TestCase {
         let logdata = playground_log_impl(1, "", TestHelpers.defaultSourceRange())
         let opt_decoded = playground_log_decode(logdata)
         let decoded = TestHelpers.unwrapOrFail(opt_decoded)
-        expectEqual(10, decoded.version)
+        expectEqual(11, decoded.version)
     }
 }
 
@@ -167,6 +167,46 @@ class StructuredTypesDecodingTestCase : TestCase {
         expectEqual(s.type, PlaygroundRepresentation.Struct.description)
         expectEqual(c.type, PlaygroundRepresentation.Class.description)
         expectEqual(t.type, PlaygroundRepresentation.Tuple.description)
+        
+        expectFalse(s.hasSuperclass)
+        expectFalse(c.hasSuperclass)
+        expectFalse(t.hasSuperclass)
+    }
+}
+    
+class BaseClassDecodingTestCase : TestCase {
+    required init?() {}
+    var name: String { return "BaseClassDecoding" }
+    var explanation: String { return "Check that base class data is correctly marked and vended" }
+    var behavior: TestBehavior { return .ExpectedSuccess }
+    func doTest() {
+        class Base {
+            var a = 1
+        }
+        class Derived: Base {
+            var b = 2
+        }
+        
+        let b = Base()
+        let d = Derived()
+        
+        let b_logdata = playground_log_impl(b, "b", TestHelpers.defaultSourceRange())
+        let d_logdata = playground_log_impl(d, "d", TestHelpers.defaultSourceRange())
+
+        let b_decoded = TestHelpers.unwrapOrFail(playground_log_decode(b_logdata))
+        let d_decoded = TestHelpers.unwrapOrFail(playground_log_decode(d_logdata))
+
+        let b_structured = TestHelpers.unwrapOrFail(b_decoded.object as? PlaygroundDecodedObject_Structured)
+        let d_structured = TestHelpers.unwrapOrFail(d_decoded.object as? PlaygroundDecodedObject_Structured)
+        
+        expectFalse(b_structured.hasSuperclass)
+        expectTrue(d_structured.hasSuperclass)
+        
+        expectEqual(d_structured.children.count, 2)
+        expectEqual(b_structured.children.count, 1)
+        expectEqual(d_structured.children[0].name, "super")
+        expectEqual(d_structured.children[1].name, "b")
+        expectEqual(b_structured.children[0].name, "a")
     }
 }
 

--- a/PlaygroundLogger/PlaygroundLogger/TestInfrastructure.swift
+++ b/PlaygroundLogger/PlaygroundLogger/TestInfrastructure.swift
@@ -106,6 +106,7 @@ public func playground_logger_test() {
         NameDecodingTestCase.self,
         BaseTypesDecodingTestCase.self,
         StructuredTypesDecodingTestCase.self,
+        BaseClassDecodingTestCase.self,
         NSNumberDecodingTestCase.self,
         OnePlusOneDecodingTestCase.self,
         MetatypeLoggingTestCase.self,


### PR DESCRIPTION
Base class data is vended as "just another child", which is mostly OK, except sometimes it's useful to know when the base class is being parsed vs. a member variable
Relying on the name "super" isn't actually correct, but at the Mirror level we actually know base class vs. ivar

This change propagates that knowledge via adding an extra byte to the payload for structured data in the logger format, such that the logger can tell consumers whether the 0th child is the base class or the first member variable

rdar://problem/19072746
