### PR TITLE
Moving QuickLook support

### DIFF
--- a/PlaygroundSupport/PlaygroundSupport/PlaygroundPage.swift
+++ b/PlaygroundSupport/PlaygroundSupport/PlaygroundPage.swift
@@ -182,3 +182,8 @@ extension NSViewController: PlaygroundLiveViewable {
     }
 }
 #endif
+
+// FIXME(ABI) the actual declarations and all the conformances should
+// be moved here before ABI stability.
+typealias CustomPlaygroundQuickLookable = Swift._CustomPlaygroundQuickLookable
+typealias PlaygroundQuickLook = Swift._PlaygroundQuickLook


### PR DESCRIPTION
**This should not be merged** before apple/swift#4089 is merged.

It begins the process of moving all QuickLook support to this project from the Standard Library.