### PR TITLE
[DO NOT MERGE] Introduced a new framework, LegacyPlaygroundQuickLookSupport.

### DIFF
--- a/LegacyPlaygroundQuickLookSupport/LegacyPlaygroundQuickLookSupport.xcodeproj/project.pbxproj
+++ b/LegacyPlaygroundQuickLookSupport/LegacyPlaygroundQuickLookSupport.xcodeproj/project.pbxproj
@@ -1,0 +1,346 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 48;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		5E0A638F201EF57A001F42CB /* AppKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0A638E201EF57A001F42CB /* AppKit.swift */; };
+		5E0A6391201EF651001F42CB /* CoreGraphics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0A6390201EF651001F42CB /* CoreGraphics.swift */; };
+		5E0A6393201EF6C6001F42CB /* Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0A6392201EF6C6001F42CB /* Foundation.swift */; };
+		5E0A6395201EF766001F42CB /* SpriteKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0A6394201EF766001F42CB /* SpriteKit.swift */; };
+		5E0A6397201EF834001F42CB /* UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0A6396201EF834001F42CB /* UIKit.swift */; };
+		5E9151B3200DC55800CAAD2E /* PlaygroundQuickLook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E9151B2200DC55800CAAD2E /* PlaygroundQuickLook.swift */; };
+		5E9151B5200DCDF300CAAD2E /* StandardLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E9151B4200DCDF300CAAD2E /* StandardLibrary.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		5E0A638E201EF57A001F42CB /* AppKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKit.swift; sourceTree = "<group>"; };
+		5E0A6390201EF651001F42CB /* CoreGraphics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreGraphics.swift; sourceTree = "<group>"; };
+		5E0A6392201EF6C6001F42CB /* Foundation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Foundation.swift; sourceTree = "<group>"; };
+		5E0A6394201EF766001F42CB /* SpriteKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpriteKit.swift; sourceTree = "<group>"; };
+		5E0A6396201EF834001F42CB /* UIKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKit.swift; sourceTree = "<group>"; };
+		5E0A6399201EFEC6001F42CB /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = ../XcodeConfig/Release.xcconfig; sourceTree = "<group>"; };
+		5E0A639A201EFEC6001F42CB /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = ../XcodeConfig/Debug.xcconfig; sourceTree = "<group>"; };
+		5E915198200DC54000CAAD2E /* LegacyPlaygroundQuickLookSupport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LegacyPlaygroundQuickLookSupport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5E91519C200DC54000CAAD2E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		5E9151B2200DC55800CAAD2E /* PlaygroundQuickLook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaygroundQuickLook.swift; sourceTree = "<group>"; };
+		5E9151B4200DCDF300CAAD2E /* StandardLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandardLibrary.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		5E915194200DC54000CAAD2E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		5E0A6398201EFEB5001F42CB /* Config Files */ = {
+			isa = PBXGroup;
+			children = (
+				5E0A639A201EFEC6001F42CB /* Debug.xcconfig */,
+				5E0A6399201EFEC6001F42CB /* Release.xcconfig */,
+			);
+			name = "Config Files";
+			sourceTree = "<group>";
+		};
+		5E91518E200DC54000CAAD2E = {
+			isa = PBXGroup;
+			children = (
+				5E91519A200DC54000CAAD2E /* LegacyPlaygroundQuickLookSupport */,
+				5E0A6398201EFEB5001F42CB /* Config Files */,
+				5E915199200DC54000CAAD2E /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		5E915199200DC54000CAAD2E /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				5E915198200DC54000CAAD2E /* LegacyPlaygroundQuickLookSupport.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		5E91519A200DC54000CAAD2E /* LegacyPlaygroundQuickLookSupport */ = {
+			isa = PBXGroup;
+			children = (
+				5E9151B2200DC55800CAAD2E /* PlaygroundQuickLook.swift */,
+				5E9151B4200DCDF300CAAD2E /* StandardLibrary.swift */,
+				5E0A638E201EF57A001F42CB /* AppKit.swift */,
+				5E0A6390201EF651001F42CB /* CoreGraphics.swift */,
+				5E0A6392201EF6C6001F42CB /* Foundation.swift */,
+				5E0A6394201EF766001F42CB /* SpriteKit.swift */,
+				5E0A6396201EF834001F42CB /* UIKit.swift */,
+				5E91519C200DC54000CAAD2E /* Info.plist */,
+			);
+			path = LegacyPlaygroundQuickLookSupport;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		5E915195200DC54000CAAD2E /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		5E915197200DC54000CAAD2E /* LegacyPlaygroundQuickLookSupport */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5E9151AC200DC54000CAAD2E /* Build configuration list for PBXNativeTarget "LegacyPlaygroundQuickLookSupport" */;
+			buildPhases = (
+				5E915193200DC54000CAAD2E /* Sources */,
+				5E915194200DC54000CAAD2E /* Frameworks */,
+				5E915195200DC54000CAAD2E /* Headers */,
+				5E915196200DC54000CAAD2E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = LegacyPlaygroundQuickLookSupport;
+			productName = LegacyPlaygroundQuickLookSupport;
+			productReference = 5E915198200DC54000CAAD2E /* LegacyPlaygroundQuickLookSupport.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		5E91518F200DC54000CAAD2E /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0920;
+				LastUpgradeCheck = 0920;
+				ORGANIZATIONNAME = "Swift project";
+				TargetAttributes = {
+					5E915197200DC54000CAAD2E = {
+						CreatedOnToolsVersion = 9.2;
+						LastSwiftMigration = 0920;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 5E915192200DC54000CAAD2E /* Build configuration list for PBXProject "LegacyPlaygroundQuickLookSupport" */;
+			compatibilityVersion = "Xcode 8.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 5E91518E200DC54000CAAD2E;
+			productRefGroup = 5E915199200DC54000CAAD2E /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				5E915197200DC54000CAAD2E /* LegacyPlaygroundQuickLookSupport */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		5E915196200DC54000CAAD2E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		5E915193200DC54000CAAD2E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5E0A638F201EF57A001F42CB /* AppKit.swift in Sources */,
+				5E9151B5200DCDF300CAAD2E /* StandardLibrary.swift in Sources */,
+				5E9151B3200DC55800CAAD2E /* PlaygroundQuickLook.swift in Sources */,
+				5E0A6393201EF6C6001F42CB /* Foundation.swift in Sources */,
+				5E0A6397201EF834001F42CB /* UIKit.swift in Sources */,
+				5E0A6391201EF651001F42CB /* CoreGraphics.swift in Sources */,
+				5E0A6395201EF766001F42CB /* SpriteKit.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		5E9151AA200DC54000CAAD2E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5E0A639A201EFEC6001F42CB /* Debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		5E9151AB200DC54000CAAD2E /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5E0A6399201EFEC6001F42CB /* Release.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		5E9151AD200DC54000CAAD2E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = LegacyPlaygroundQuickLookSupport/Info.plist;
+				INSTALL_PATH = "$(PGS_FRAMEWORKS_DIR_FOR_INSTALL)";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.swift.LegacyPlaygroundQuickLookSupport;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SWIFT_VERSION = 4.0;
+			};
+			name = Debug;
+		};
+		5E9151AE200DC54000CAAD2E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = LegacyPlaygroundQuickLookSupport/Info.plist;
+				INSTALL_PATH = "$(PGS_FRAMEWORKS_DIR_FOR_INSTALL)";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = org.swift.LegacyPlaygroundQuickLookSupport;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SWIFT_VERSION = 4.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		5E915192200DC54000CAAD2E /* Build configuration list for PBXProject "LegacyPlaygroundQuickLookSupport" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5E9151AA200DC54000CAAD2E /* Debug */,
+				5E9151AB200DC54000CAAD2E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5E9151AC200DC54000CAAD2E /* Build configuration list for PBXNativeTarget "LegacyPlaygroundQuickLookSupport" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5E9151AD200DC54000CAAD2E /* Debug */,
+				5E9151AE200DC54000CAAD2E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 5E91518F200DC54000CAAD2E /* Project object */;
+}

--- a/LegacyPlaygroundQuickLookSupport/LegacyPlaygroundQuickLookSupport.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/LegacyPlaygroundQuickLookSupport/LegacyPlaygroundQuickLookSupport.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:LegacyPlaygroundQuickLookSupport.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/LegacyPlaygroundQuickLookSupport/LegacyPlaygroundQuickLookSupport/AppKit.swift
+++ b/LegacyPlaygroundQuickLookSupport/LegacyPlaygroundQuickLookSupport/AppKit.swift
@@ -1,0 +1,52 @@
+//===--- AppKit.swift -----------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014-2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if os(macOS)
+
+import AppKit
+
+extension NSCursor : _DefaultCustomPlaygroundQuickLookable {
+    public var _defaultCustomPlaygroundQuickLook: PlaygroundQuickLook {
+        return .image(image)
+    }
+}
+
+fileprivate var quickLookViews = Set<NSView>()
+
+extension NSView : _DefaultCustomPlaygroundQuickLookable {
+    public var _defaultCustomPlaygroundQuickLook: PlaygroundQuickLook {
+        // if you set NSView.needsDisplay, you can get yourself in a recursive scenario where the same view
+        // could need to draw itself in order to get a QLObject for itself, which in turn if your code was
+        // instrumented to log on-draw, would cause yourself to get back here and so on and so forth
+        // until you run out of stack and crash
+        // This code checks that we aren't trying to log the same view recursively - and if so just returns
+        // an empty view, which is probably a safer option than crashing
+        // FIXME: is there a way to say "cacheDisplayInRect butDoNotRedrawEvenIfISaidSo"?
+        if quickLookViews.contains(self) {
+            return .view(NSImage())
+        } else {
+            quickLookViews.insert(self)
+            let result: PlaygroundQuickLook
+            if let b = bitmapImageRepForCachingDisplay(in: bounds) {
+                cacheDisplay(in: bounds, to: b)
+                result = .view(b)
+            } else {
+                result = .view(NSImage())
+            }
+            quickLookViews.remove(self)
+            return result
+        }
+    }
+}
+
+    
+#endif

--- a/LegacyPlaygroundQuickLookSupport/LegacyPlaygroundQuickLookSupport/CoreGraphics.swift
+++ b/LegacyPlaygroundQuickLookSupport/LegacyPlaygroundQuickLookSupport/CoreGraphics.swift
@@ -1,0 +1,31 @@
+//===--- CoreGraphics.swift -----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014-2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import CoreGraphics
+
+extension CGPoint: CustomPlaygroundQuickLookable {
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .point(Double(x), Double(y))
+    }
+}
+
+extension CGSize: CustomPlaygroundQuickLookable {
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .size(Double(width), Double(height))
+    }
+}
+
+extension CGRect: CustomPlaygroundQuickLookable {
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .rectangle(Double(origin.x), Double(origin.y), Double(size.width), Double(size.height))
+    }
+}

--- a/LegacyPlaygroundQuickLookSupport/LegacyPlaygroundQuickLookSupport/Foundation.swift
+++ b/LegacyPlaygroundQuickLookSupport/LegacyPlaygroundQuickLookSupport/Foundation.swift
@@ -1,0 +1,64 @@
+//===--- Foundation.swift -------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014-2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+extension Date : CustomPlaygroundQuickLookable {
+    private var summary: String {
+        let df = DateFormatter()
+        df.dateStyle = .medium
+        df.timeStyle = .short
+        return df.string(from: self)
+    }
+    
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .text(summary)
+    }
+}
+
+extension NSDate : CustomPlaygroundQuickLookable {
+    @nonobjc private var summary: String {
+        let df = DateFormatter()
+        df.dateStyle = .medium
+        df.timeStyle = .short
+        return df.string(from: self as Date)
+    }
+    
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .text(summary)
+    }
+}
+
+extension NSRange : CustomPlaygroundQuickLookable {
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .range(Int64(location), Int64(length))
+    }
+}
+
+extension NSString : CustomPlaygroundQuickLookable {
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .text(self as String)
+    }
+}
+
+extension NSURL : CustomPlaygroundQuickLookable {
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        guard let str = absoluteString else { return .text("Unknown URL") }
+        return .url(str)
+    }
+}
+
+extension URL : CustomPlaygroundQuickLookable {
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .url(absoluteString)
+    }
+}

--- a/LegacyPlaygroundQuickLookSupport/LegacyPlaygroundQuickLookSupport/Info.plist
+++ b/LegacyPlaygroundQuickLookSupport/LegacyPlaygroundQuickLookSupport/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/LegacyPlaygroundQuickLookSupport/LegacyPlaygroundQuickLookSupport/PlaygroundQuickLook.swift
+++ b/LegacyPlaygroundQuickLookSupport/LegacyPlaygroundQuickLookSupport/PlaygroundQuickLook.swift
@@ -1,0 +1,267 @@
+//===--- PlaygroundQuickLook.swift ----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014-2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+#if os(macOS)
+    import AppKit
+#endif
+
+#if os(iOS) || os(tvOS)
+    import UIKit
+#endif
+
+import CoreImage
+
+@objc
+private class DebugQuickLookObjectShim: NSObject {
+    @objc(debugQuickLookObject)
+    func debugQuickLookObject() -> AnyObject? { return nil }
+}
+
+/// The sum of types that can be used as a Quick Look representation.
+public enum PlaygroundQuickLook {
+    /// Plain text.
+    case text(String)
+    
+    /// An integer numeric value.
+    case int(Int64)
+    
+    /// An unsigned integer numeric value.
+    case uInt(UInt64)
+    
+    /// A single precision floating-point numeric value.
+    case float(Float32)
+    
+    /// A double precision floating-point numeric value.
+    case double(Float64)
+    
+    // FIXME: Uses an Any to avoid coupling a particular Cocoa type.
+    /// An image.
+    case image(Any)
+    
+    // FIXME: Uses an Any to avoid coupling a particular Cocoa type.
+    /// A sound.
+    case sound(Any)
+    
+    // FIXME: Uses an Any to avoid coupling a particular Cocoa type.
+    /// A color.
+    case color(Any)
+    
+    // FIXME: Uses an Any to avoid coupling a particular Cocoa type.
+    /// A bezier path.
+    case bezierPath(Any)
+    
+    // FIXME: Uses an Any to avoid coupling a particular Cocoa type.
+    /// An attributed string.
+    case attributedString(Any)
+    
+    // FIXME: Uses explicit coordinates to avoid coupling a particular Cocoa type.
+    /// A rectangle.
+    case rectangle(Float64, Float64, Float64, Float64)
+    
+    // FIXME: Uses explicit coordinates to avoid coupling a particular Cocoa type.
+    /// A point.
+    case point(Float64, Float64)
+    
+    // FIXME: Uses explicit coordinates to avoid coupling a particular Cocoa type.
+    /// A size.
+    case size(Float64, Float64)
+    
+    /// A boolean value.
+    case bool(Bool)
+    
+    // FIXME: Uses explicit values to avoid coupling a particular Cocoa type.
+    /// A range.
+    case range(Int64, Int64)
+    
+    // FIXME: Uses an Any to avoid coupling a particular Cocoa type.
+    /// A GUI view.
+    case view(Any)
+    
+    // FIXME: Uses an Any to avoid coupling a particular Cocoa type.
+    /// A graphical sprite.
+    case sprite(Any)
+    
+    /// A Uniform Resource Locator.
+    case url(String)
+    
+    /// Raw data that has already been encoded in a format the IDE understands.
+    case _raw([UInt8], String)
+}
+
+extension PlaygroundQuickLook {
+    /// Creates a new Quick Look for the given instance.
+    ///
+    /// If the dynamic type of `subject` conforms to
+    /// `CustomPlaygroundQuickLookable`, the result is found by calling its
+    /// `customPlaygroundQuickLook` property. Otherwise, the result is
+    /// synthesized by the language. In some cases, the synthesized result may
+    /// be `.text(String(reflecting: subject))`.
+    ///
+    /// - Note: If the dynamic type of `subject` has value semantics, subsequent
+    ///   mutations of `subject` will not observable in the Quick Look. In
+    ///   general, though, the observability of such mutations is unspecified.
+    ///
+    /// - Parameter subject: The instance to represent with the resulting Quick
+    ///   Look.
+    public init(reflecting subject: Any) {
+        // If the subject conforms to CustomPlaygroundQuickLookable, use that.
+        if let customized = subject as? CustomPlaygroundQuickLookable {
+            self = customized.customPlaygroundQuickLook
+        }
+            
+        // If the subject conforms to _DefaultCustomPlaygroundQuickLookable, use that.
+        else if let customized = subject as? _DefaultCustomPlaygroundQuickLookable {
+            self = customized._defaultCustomPlaygroundQuickLook
+        }
+            
+        // Otherwise, fall back to the default behavior (previously provided by the legacy _Mirror).
+        else {
+            // If the subject is an Objective-C object implementing -debugQuickLookObject, use that.
+            if let debugQuickLookObjectMethod = (subject as AnyObject).debugQuickLookObject,
+               let returnedObject = debugQuickLookObjectMethod(),
+               let debugQuickLookObject = returnedObject as? DebugQuickLookObject {
+                self = debugQuickLookObject.convertToPlaygroundQuickLook()
+            }
+            
+            // If the subject itself is an object which can be returned from -debugQuickLookObject, use that.
+            else if let debugQuickLookObject = subject as? DebugQuickLookObject {
+                self = debugQuickLookObject.convertToPlaygroundQuickLook()
+            }
+            
+            // Otherwise, fall back to a textual representation of the subject.
+            else {
+                self = .text(String(reflecting: subject))
+            }
+        }
+    }
+}
+
+/// A type that explicitly supplies its own playground Quick Look.
+///
+/// A Quick Look can be created for an instance of any type by using the
+/// `PlaygroundQuickLook(reflecting:)` initializer. If you are not satisfied
+/// with the representation supplied for your type by default, you can make it
+/// conform to the `CustomPlaygroundQuickLookable` protocol and provide a
+/// custom `PlaygroundQuickLook` instance.
+public protocol CustomPlaygroundQuickLookable {
+    /// A custom playground Quick Look for this instance.
+    ///
+    /// If this type has value semantics, the `PlaygroundQuickLook` instance
+    /// should be unaffected by subsequent mutations.
+    var customPlaygroundQuickLook: PlaygroundQuickLook { get }
+}
+
+// A workaround for <rdar://problem/26182650>
+public protocol _DefaultCustomPlaygroundQuickLookable {
+    var _defaultCustomPlaygroundQuickLook: PlaygroundQuickLook { get }
+}
+
+// MARK: - DebugQuickLookObject protocol and conformances
+
+/// A protocol which allows types to be valid values returned by
+/// `-debugQuickLookObject`.
+fileprivate protocol DebugQuickLookObject: class {
+    func convertToPlaygroundQuickLook() -> PlaygroundQuickLook
+}
+
+extension NSNumber: DebugQuickLookObject {
+    fileprivate func convertToPlaygroundQuickLook() -> PlaygroundQuickLook {
+        switch UInt8(self.objCType[0]) {
+        case UInt8(ascii: "d"):
+            return .double(doubleValue)
+        case UInt8(ascii: "f"):
+            return .float(floatValue)
+        case UInt8(ascii: "Q"):
+            return .uInt(uint64Value)
+        default:
+            return .int(int64Value)
+        }
+    }
+}
+
+extension NSAttributedString: DebugQuickLookObject {
+    fileprivate func convertToPlaygroundQuickLook() -> PlaygroundQuickLook {
+        return .attributedString(self)
+    }
+}
+
+#if os(macOS)
+    extension NSImage: DebugQuickLookObject {
+        fileprivate func convertToPlaygroundQuickLook() -> PlaygroundQuickLook {
+            return .image(self)
+        }
+    }
+    
+    extension NSImageView: DebugQuickLookObject {
+        fileprivate func convertToPlaygroundQuickLook() -> PlaygroundQuickLook {
+            return .image(self)
+        }
+    }
+    
+    extension NSBitmapImageRep: DebugQuickLookObject {
+        fileprivate func convertToPlaygroundQuickLook() -> PlaygroundQuickLook {
+            return .image(self)
+        }
+    }
+    
+    extension NSColor: DebugQuickLookObject {
+        fileprivate func convertToPlaygroundQuickLook() -> PlaygroundQuickLook {
+            return .color(self)
+        }
+    }
+    
+    extension NSBezierPath: DebugQuickLookObject {
+        fileprivate func convertToPlaygroundQuickLook() -> PlaygroundQuickLook {
+            return .bezierPath(self)
+        }
+    }
+#endif
+
+#if os(iOS) || os(tvOS)
+    extension UIImage: DebugQuickLookObject {
+        fileprivate func convertToPlaygroundQuickLook() -> PlaygroundQuickLook {
+            return .image(self)
+        }
+    }
+    
+    extension UIImageView: DebugQuickLookObject {
+        fileprivate func convertToPlaygroundQuickLook() -> PlaygroundQuickLook {
+            return .image(self)
+        }
+    }
+
+    extension UIColor: DebugQuickLookObject {
+        fileprivate func convertToPlaygroundQuickLook() -> PlaygroundQuickLook {
+            return .color(self)
+        }
+    }
+    
+    extension UIBezierPath: DebugQuickLookObject {
+        fileprivate func convertToPlaygroundQuickLook() -> PlaygroundQuickLook {
+            return .bezierPath(self)
+        }
+    }
+#endif
+
+extension CIImage: DebugQuickLookObject {
+    fileprivate func convertToPlaygroundQuickLook() -> PlaygroundQuickLook {
+        return .image(self)
+    }
+}
+
+extension NSString: DebugQuickLookObject {
+    fileprivate func convertToPlaygroundQuickLook() -> PlaygroundQuickLook {
+        return .text(self as String)
+    }
+}

--- a/LegacyPlaygroundQuickLookSupport/LegacyPlaygroundQuickLookSupport/SpriteKit.swift
+++ b/LegacyPlaygroundQuickLookSupport/LegacyPlaygroundQuickLookSupport/SpriteKit.swift
@@ -1,0 +1,90 @@
+//===--- SpriteKit.swift --------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014-2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SpriteKit
+
+// this class only exists to allow AnyObject lookup of _copyImageData
+// since that method only exists in a private header in SpriteKit, the lookup
+// mechanism by default fails to accept it as a valid AnyObject call
+@objc fileprivate class _SpriteKitMethodProvider: NSObject {
+    override init() { _sanityCheckFailure("don't touch me") }
+    @objc func _copyImageData() -> NSData! { return nil }
+}
+
+extension SKShapeNode: CustomPlaygroundQuickLookable {
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        let data = (self as AnyObject)._copyImageData?() as Data?
+        
+        // we could send a Raw, but I don't want to make a copy of the
+        // bytes for no good reason make an NSImage out of them and
+        // send that
+        #if os(macOS)
+            let image = data.flatMap(NSImage.init(data:)) ?? NSImage()
+        #elseif os(iOS) || os(watchOS) || os(tvOS)
+            let image = data.flatMap(UIImage.init(data:)) ?? UIImage()
+        #endif
+        
+        return .sprite(image)
+    }
+}
+
+extension SKSpriteNode: CustomPlaygroundQuickLookable {
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        let data = (self as AnyObject)._copyImageData?() as Data?
+        
+        // we could send a Raw, but I don't want to make a copy of the
+        // bytes for no good reason make an NSImage out of them and
+        // send that
+        #if os(macOS)
+            let image = data.flatMap(NSImage.init(data:)) ?? NSImage()
+        #elseif os(iOS) || os(watchOS) || os(tvOS)
+            let image = data.flatMap(UIImage.init(data:)) ?? UIImage()
+        #endif
+        
+        return .sprite(image)
+    }
+}
+
+extension SKTextureAtlas: CustomPlaygroundQuickLookable {
+  public var customPlaygroundQuickLook: PlaygroundQuickLook {
+    let data = (self as AnyObject)._copyImageData?() as Data?
+
+    // we could send a Raw, but I don't want to make a copy of the
+    // bytes for no good reason make an NSImage out of them and
+    // send that
+#if os(macOS)
+    let image = data.flatMap(NSImage.init(data:)) ?? NSImage()
+#elseif os(iOS) || os(watchOS) || os(tvOS)
+    let image = data.flatMap(UIImage.init(data:)) ?? UIImage()
+#endif
+
+    return .sprite(image)
+  }
+}
+
+extension SKTexture: CustomPlaygroundQuickLookable {
+  public var customPlaygroundQuickLook: PlaygroundQuickLook {
+    let data = (self as AnyObject)._copyImageData?() as Data?
+
+    // we could send a Raw, but I don't want to make a copy of the
+    // bytes for no good reason make an NSImage out of them and
+    // send that
+#if os(macOS)
+    let image = data.flatMap(NSImage.init(data:)) ?? NSImage()
+#elseif os(iOS) || os(watchOS) || os(tvOS)
+    let image = data.flatMap(UIImage.init(data:)) ?? UIImage()
+#endif
+
+    return .sprite(image)
+  }
+}
+

--- a/LegacyPlaygroundQuickLookSupport/LegacyPlaygroundQuickLookSupport/StandardLibrary.swift
+++ b/LegacyPlaygroundQuickLookSupport/LegacyPlaygroundQuickLookSupport/StandardLibrary.swift
@@ -1,0 +1,180 @@
+//===--- StandardLibrary.swift --------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014-2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+extension Float: CustomPlaygroundQuickLookable {
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .float(self)
+    }
+}
+
+extension Double: CustomPlaygroundQuickLookable {
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .double(self)
+    }
+}
+
+extension Bool: CustomPlaygroundQuickLookable {
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .bool(self)
+    }
+}
+
+extension String: CustomPlaygroundQuickLookable {
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .text(self)
+    }
+}
+
+extension Character: CustomPlaygroundQuickLookable {
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .text(String(self))
+    }
+}
+
+extension Unicode.Scalar: CustomPlaygroundQuickLookable {
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .uInt(UInt64(self))
+    }
+}
+
+extension Int: CustomPlaygroundQuickLookable {
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .int(Int64(self))
+    }
+}
+
+extension Int8: CustomPlaygroundQuickLookable {
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .int(Int64(self))
+    }
+}
+
+extension Int16: CustomPlaygroundQuickLookable {
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .int(Int64(self))
+    }
+}
+
+extension Int32: CustomPlaygroundQuickLookable {
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .int(Int64(self))
+    }
+}
+
+extension Int64: CustomPlaygroundQuickLookable {
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .int(self)
+    }
+}
+
+extension UInt: CustomPlaygroundQuickLookable {
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .uInt(UInt64(self))
+    }
+}
+
+extension UInt8: CustomPlaygroundQuickLookable {
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .uInt(UInt64(self))
+    }
+}
+
+extension UInt16: CustomPlaygroundQuickLookable {
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .uInt(UInt64(self))
+    }
+}
+
+extension UInt32: CustomPlaygroundQuickLookable {
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .uInt(UInt64(self))
+    }
+}
+
+extension UInt64: CustomPlaygroundQuickLookable {
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .uInt(self)
+    }
+}
+
+extension String.UnicodeScalarView: CustomPlaygroundQuickLookable {
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .text(description)
+    }
+}
+
+extension String.UTF16View: CustomPlaygroundQuickLookable {
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .text(description)
+    }
+}
+
+extension String.UTF8View: CustomPlaygroundQuickLookable {
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .text(description)
+    }
+}
+
+extension Substring: CustomPlaygroundQuickLookable {
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return String(self).customPlaygroundQuickLook
+    }
+}
+
+extension UnsafePointer: CustomPlaygroundQuickLookable {
+    private var summary: String {
+        let selfType = "UnsafePointer"
+        let ptrValue = UInt64(bitPattern: Int64(Int(bitPattern: self)))
+        return ptrValue == 0 ? "\(selfType)(nil)" : "\(selfType)(0x\(_uint64ToString(ptrValue, radix:16, uppercase:true)))"
+    }
+    
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .text(summary)
+    }
+}
+
+extension UnsafeMutablePointer: CustomPlaygroundQuickLookable {
+    private var summary: String {
+        let selfType = "UnsafeMutablePointer"
+        let ptrValue = UInt64(bitPattern: Int64(Int(bitPattern: self)))
+        return ptrValue == 0 ? "\(selfType)(nil)" : "\(selfType)(0x\(_uint64ToString(ptrValue, radix:16, uppercase:true)))"
+    }
+    
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .text(summary)
+    }
+}
+
+extension UnsafeRawPointer : CustomPlaygroundQuickLookable {
+    private var summary: String {
+        let selfType = "UnsafeRawPointer"
+        let ptrValue = UInt64(bitPattern: Int64(Int(bitPattern: self)))
+        return ptrValue == 0 ? "\(selfType)(nil)" : "\(selfType)(0x\(_uint64ToString(ptrValue, radix:16, uppercase:true)))"
+    }
+    
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .text(summary)
+    }
+}
+
+extension UnsafeMutableRawPointer : CustomPlaygroundQuickLookable {
+    private var summary: String {
+        let selfType = "UnsafeMutableRawPointer"
+        let ptrValue = UInt64(bitPattern: Int64(Int(bitPattern: self)))
+        return ptrValue == 0 ? "\(selfType)(nil)" : "\(selfType)(0x\(_uint64ToString(ptrValue, radix:16, uppercase:true)))"
+    }
+    
+    public var customPlaygroundQuickLook: PlaygroundQuickLook {
+        return .text(summary)
+    }
+}
+

--- a/LegacyPlaygroundQuickLookSupport/LegacyPlaygroundQuickLookSupport/UIKit.swift
+++ b/LegacyPlaygroundQuickLookSupport/LegacyPlaygroundQuickLookSupport/UIKit.swift
@@ -1,0 +1,49 @@
+//===--- UIKit.swift --------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014-2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if os(iOS) || os(tvOS)
+    
+import UIKit
+
+fileprivate var quickLookViews = Set<UIView>()
+
+extension UIView : _DefaultCustomPlaygroundQuickLookable {
+    public var _defaultCustomPlaygroundQuickLook: PlaygroundQuickLook {
+        if quickLookViews.contains(self) {
+            return .view(UIImage())
+        } else {
+            quickLookViews.insert(self)
+            // in case of an empty rectangle abort the logging
+            if (bounds.size.width == 0) || (bounds.size.height == 0) {
+                return .view(UIImage())
+            }
+            
+            UIGraphicsBeginImageContextWithOptions(bounds.size, false, 0.0)
+            // UIKit is about to update this to be optional, so make it work
+            // with both older and newer SDKs. (In this context it should always
+            // be present.)
+            let ctx: CGContext! = UIGraphicsGetCurrentContext()
+            UIColor(white:1.0, alpha:0.0).set()
+            ctx.fill(bounds)
+            layer.render(in: ctx)
+            
+            let image: UIImage! = UIGraphicsGetImageFromCurrentImageContext()
+            
+            UIGraphicsEndImageContext()
+            
+            quickLookViews.remove(self)
+            return .view(image)
+        }
+    }
+}
+
+#endif

--- a/PlaygroundLogger/PlaygroundLogger.xcodeproj/project.pbxproj
+++ b/PlaygroundLogger/PlaygroundLogger.xcodeproj/project.pbxproj
@@ -209,6 +209,41 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		5E0A6384201EE985001F42CB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5E0A637F201EE985001F42CB /* LegacyPlaygroundQuickLookSupport.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 5E915198200DC54000CAAD2E;
+			remoteInfo = LegacyPlaygroundQuickLookSupport;
+		};
+		5E0A6386201EE985001F42CB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5E0A637F201EE985001F42CB /* LegacyPlaygroundQuickLookSupport.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 5E9151A1200DC54000CAAD2E;
+			remoteInfo = LegacyPlaygroundQuickLookSupportTests;
+		};
+		5E0A6388201EE990001F42CB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5E0A637F201EE985001F42CB /* LegacyPlaygroundQuickLookSupport.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 5E915197200DC54000CAAD2E;
+			remoteInfo = LegacyPlaygroundQuickLookSupport;
+		};
+		5E0A638A201EE995001F42CB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5E0A637F201EE985001F42CB /* LegacyPlaygroundQuickLookSupport.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 5E915197200DC54000CAAD2E;
+			remoteInfo = LegacyPlaygroundQuickLookSupport;
+		};
+		5E0A638C201EE999001F42CB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5E0A637F201EE985001F42CB /* LegacyPlaygroundQuickLookSupport.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 5E915197200DC54000CAAD2E;
+			remoteInfo = LegacyPlaygroundQuickLookSupport;
+		};
 		62EF801D1925C9000062D058 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 1D7FD51218BFE00400C718C6 /* Project object */;
@@ -296,6 +331,7 @@
 /* Begin PBXFileReference section */
 		5E06BF1319BA882000C5C2DE /* PlaygroundLogger.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = PlaygroundLogger.modulemap; sourceTree = "<group>"; };
 		5E06BF1519BA883700C5C2DE /* PlaygroundLogger.private.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = PlaygroundLogger.private.modulemap; sourceTree = "<group>"; };
+		5E0A637F201EE985001F42CB /* LegacyPlaygroundQuickLookSupport.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = LegacyPlaygroundQuickLookSupport.xcodeproj; path = ../LegacyPlaygroundQuickLookSupport/LegacyPlaygroundQuickLookSupport.xcodeproj; sourceTree = "<group>"; };
 		5E6C2B491FEB16F800DEE489 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = ../XcodeConfig/Release.xcconfig; sourceTree = "<group>"; };
 		5E6C2B4A1FEB16F800DEE489 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = ../XcodeConfig/Debug.xcconfig; sourceTree = "<group>"; };
 		5EA8B30F18D12FF8007A88F4 /* PlaygroundLogger-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "PlaygroundLogger-Info.plist"; sourceTree = "<group>"; };
@@ -403,6 +439,7 @@
 				A80FEB461C59457B004E722A /* PlaygroundLogger_tvOS */,
 				1D80230A18C6A09600D522B2 /* SupportingFiles */,
 				5E6C2B481FEB16D300DEE489 /* Config Files */,
+				5E0A637E201EE979001F42CB /* Referenced Projects */,
 				5E7F988818CEA2CA003F50B8 /* Frameworks */,
 				1D7FD51B18BFE00400C718C6 /* Products */,
 			);
@@ -424,6 +461,23 @@
 			children = (
 			);
 			path = SupportingFiles;
+			sourceTree = "<group>";
+		};
+		5E0A637E201EE979001F42CB /* Referenced Projects */ = {
+			isa = PBXGroup;
+			children = (
+				5E0A637F201EE985001F42CB /* LegacyPlaygroundQuickLookSupport.xcodeproj */,
+			);
+			name = "Referenced Projects";
+			sourceTree = "<group>";
+		};
+		5E0A6380201EE985001F42CB /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				5E0A6385201EE985001F42CB /* LegacyPlaygroundQuickLookSupport.framework */,
+				5E0A6387201EE985001F42CB /* LegacyPlaygroundQuickLookSupportTests.xctest */,
+			);
+			name = Products;
 			sourceTree = "<group>";
 		};
 		5E6C2B481FEB16D300DEE489 /* Config Files */ = {
@@ -618,6 +672,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				5E0A638B201EE995001F42CB /* PBXTargetDependency */,
 			);
 			name = PlaygroundLogger_iOS;
 			productName = PlaygroundLogger_iOS;
@@ -653,6 +708,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				5E0A6389201EE990001F42CB /* PBXTargetDependency */,
 			);
 			name = PlaygroundLogger;
 			productName = PlaygroundLogger;
@@ -671,6 +727,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				5E0A638D201EE999001F42CB /* PBXTargetDependency */,
 			);
 			name = PlaygroundLogger_tvOS;
 			productName = PlaygroundLogger_iOS;
@@ -733,6 +790,12 @@
 			mainGroup = 1D7FD51118BFE00400C718C6;
 			productRefGroup = 1D7FD51B18BFE00400C718C6 /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 5E0A6380201EE985001F42CB /* Products */;
+					ProjectRef = 5E0A637F201EE985001F42CB /* LegacyPlaygroundQuickLookSupport.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				1D0D20A518C69600001A2102 /* PlaygroundLogger_Mac_Products */,
@@ -748,6 +811,23 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		5E0A6385201EE985001F42CB /* LegacyPlaygroundQuickLookSupport.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = LegacyPlaygroundQuickLookSupport.framework;
+			remoteRef = 5E0A6384201EE985001F42CB /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		5E0A6387201EE985001F42CB /* LegacyPlaygroundQuickLookSupportTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = LegacyPlaygroundQuickLookSupportTests.xctest;
+			remoteRef = 5E0A6386201EE985001F42CB /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		622D8E0318F615D200D064D0 /* Resources */ = {
@@ -927,6 +1007,21 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		5E0A6389201EE990001F42CB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = LegacyPlaygroundQuickLookSupport;
+			targetProxy = 5E0A6388201EE990001F42CB /* PBXContainerItemProxy */;
+		};
+		5E0A638B201EE995001F42CB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = LegacyPlaygroundQuickLookSupport;
+			targetProxy = 5E0A638A201EE995001F42CB /* PBXContainerItemProxy */;
+		};
+		5E0A638D201EE999001F42CB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = LegacyPlaygroundQuickLookSupport;
+			targetProxy = 5E0A638C201EE999001F42CB /* PBXContainerItemProxy */;
+		};
 		62EF801E1925C9000062D058 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 622D8E0418F615D200D064D0 /* PlaygroundLogger_iOS */;

--- a/PlaygroundLogger/PlaygroundLogger/Common.swift
+++ b/PlaygroundLogger/PlaygroundLogger/Common.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import LegacyPlaygroundQuickLookSupport
 
 typealias SourceLocation = (line: UInt64, col: UInt64)
 typealias SourceRange = (begin: SourceLocation, end: SourceLocation)
@@ -21,7 +22,7 @@ protocol Serializable {
 }
 
 typealias ChildrenRange = CountableRange<UInt64>
-typealias QuickLookObject = Swift.PlaygroundQuickLook
+typealias QuickLookObject = LegacyPlaygroundQuickLookSupport.PlaygroundQuickLook
 
 // given a disparate array of ranges, return a possibly smaller such array such that
 // no two ranges overlap and ranges are sorted by their startIndex

--- a/PlaygroundLogger/PlaygroundLogger/LoggerMirror.swift
+++ b/PlaygroundLogger/PlaygroundLogger/LoggerMirror.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import LegacyPlaygroundQuickLookSupport
+
 // a wrapper over the reflection APIs providing a one-stop shop for all the things PlaygroundLogger needs
 
 final class LoggerMirror {

--- a/PlaygroundLogger/PlaygroundLogger/TestCases.swift
+++ b/PlaygroundLogger/PlaygroundLogger/TestCases.swift
@@ -14,6 +14,8 @@
 #else
 import StdlibUnittest
 
+import LegacyPlaygroundQuickLookSupport
+
 #if os(OSX)
 import Cocoa
 #else

--- a/swift-xcode-playground-support.xcworkspace/contents.xcworkspacedata
+++ b/swift-xcode-playground-support.xcworkspace/contents.xcworkspacedata
@@ -7,4 +7,7 @@
    <FileRef
       location = "group:PlaygroundSupport/PlaygroundSupport.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:LegacyPlaygroundQuickLookSupport/LegacyPlaygroundQuickLookSupport.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/swift-xcode-playground-support.xcworkspace/xcshareddata/xcschemes/BuildScript-iOS.xcscheme
+++ b/swift-xcode-playground-support.xcworkspace/xcshareddata/xcschemes/BuildScript-iOS.xcscheme
@@ -48,6 +48,20 @@
                ReferencedContainer = "container:PlaygroundSupport/PlaygroundSupport.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5E915197200DC54000CAAD2E"
+               BuildableName = "LegacyPlaygroundQuickLookSupport.framework"
+               BlueprintName = "LegacyPlaygroundQuickLookSupport"
+               ReferencedContainer = "container:LegacyPlaygroundQuickLookSupport/LegacyPlaygroundQuickLookSupport.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/swift-xcode-playground-support.xcworkspace/xcshareddata/xcschemes/BuildScript-macOS.xcscheme
+++ b/swift-xcode-playground-support.xcworkspace/xcshareddata/xcschemes/BuildScript-macOS.xcscheme
@@ -48,6 +48,20 @@
                ReferencedContainer = "container:PlaygroundSupport/PlaygroundSupport.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5E915197200DC54000CAAD2E"
+               BuildableName = "LegacyPlaygroundQuickLookSupport.framework"
+               BlueprintName = "LegacyPlaygroundQuickLookSupport"
+               ReferencedContainer = "container:LegacyPlaygroundQuickLookSupport/LegacyPlaygroundQuickLookSupport.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/swift-xcode-playground-support.xcworkspace/xcshareddata/xcschemes/BuildScript-tvOS.xcscheme
+++ b/swift-xcode-playground-support.xcworkspace/xcshareddata/xcschemes/BuildScript-tvOS.xcscheme
@@ -48,6 +48,20 @@
                ReferencedContainer = "container:PlaygroundSupport/PlaygroundSupport.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5E915197200DC54000CAAD2E"
+               BuildableName = "LegacyPlaygroundQuickLookSupport.framework"
+               BlueprintName = "LegacyPlaygroundQuickLookSupport"
+               ReferencedContainer = "container:LegacyPlaygroundQuickLookSupport/LegacyPlaygroundQuickLookSupport.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction


### PR DESCRIPTION
This framework provides the PlaygroundQuickLook enum and the CustomPlaygroundQuickLookable protocol.
It is intended as a legacy transition shim, suitable for import into playgrounds targeting pre-Swift 5 so they continue to build even though the standard library no longer includes PlaygroundQuickLook or CustomPlaygroundQuickLookable.

As part of this, updated PlaygroundLogger to use LegacyPlaygroundQuickLookSupport when generating logger results.

This is for a [swift-evolution proposal](https://github.com/cwakamo/swift-evolution/blob/playground-quicklook-api-revamp/proposals/nnnn-playground-quicklook-api-revamp.md) which proposes removing `PlaygroundQuickLook` and `CustomPlaygroundQuickLookable` from the standard library while maintaining a legacy shim library for use in pre-Swift 5 playgrounds, and it goes with apple/swift#14252.