### PR TITLE
[DO NOT MERGE][PlaygroundSupport] Introduced CustomPlaygroundDisplayConvertible.

### DIFF
--- a/PlaygroundSupport/PlaygroundSupport.xcodeproj/project.pbxproj
+++ b/PlaygroundSupport/PlaygroundSupport.xcodeproj/project.pbxproj
@@ -97,6 +97,9 @@
 
 /* Begin PBXBuildFile section */
 		1D31347D18DCE66E00891152 /* XCPValueHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D31347C18DCE66E00891152 /* XCPValueHistory.swift */; };
+		5E08F29B201FEFE100ED74A2 /* CustomPlaygroundDisplayConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E08F29A201FEFE100ED74A2 /* CustomPlaygroundDisplayConvertible.swift */; };
+		5E08F29C201FEFE100ED74A2 /* CustomPlaygroundDisplayConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E08F29A201FEFE100ED74A2 /* CustomPlaygroundDisplayConvertible.swift */; };
+		5E08F29D201FEFE100ED74A2 /* CustomPlaygroundDisplayConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E08F29A201FEFE100ED74A2 /* CustomPlaygroundDisplayConvertible.swift */; };
 		5E3FBDBA1970725D000BC36F /* XCPSharedDataDirectory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E3FBDB81970721F000BC36F /* XCPSharedDataDirectory.swift */; };
 		5E3FBDBB1970725D000BC36F /* XCPSharedDataDirectory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E3FBDB81970721F000BC36F /* XCPSharedDataDirectory.swift */; };
 		5EC01A1F1BA0DE86008FCDB1 /* XCPlaygroundPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC01A1E1BA0DE86008FCDB1 /* XCPlaygroundPage.swift */; };
@@ -329,6 +332,7 @@
 /* Begin PBXFileReference section */
 		1D31347C18DCE66E00891152 /* XCPValueHistory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCPValueHistory.swift; sourceTree = "<group>"; };
 		1DF4117818DCB596001CDFC7 /* XCPlayground.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = XCPlayground.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5E08F29A201FEFE100ED74A2 /* CustomPlaygroundDisplayConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPlaygroundDisplayConvertible.swift; sourceTree = "<group>"; };
 		5E3FBDB81970721F000BC36F /* XCPSharedDataDirectory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCPSharedDataDirectory.swift; sourceTree = "<group>"; };
 		5E6C2B461FE9DCD000DEE489 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = ../XcodeConfig/Debug.xcconfig; sourceTree = "<group>"; };
 		5E6C2B471FE9DCDD00DEE489 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = ../XcodeConfig/Release.xcconfig; sourceTree = "<group>"; };
@@ -548,6 +552,7 @@
 			children = (
 				5ECA7DC31FDF579C005D0A3F /* PlaygroundSupport.h */,
 				A8318FD81CF604D50015809A /* PlaygroundPage.swift */,
+				5E08F29A201FEFE100ED74A2 /* CustomPlaygroundDisplayConvertible.swift */,
 				A8318FF41CF605CF0015809A /* PlaygroundSupport-Info.plist */,
 			);
 			path = PlaygroundSupport;
@@ -1097,6 +1102,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5E08F29B201FEFE100ED74A2 /* CustomPlaygroundDisplayConvertible.swift in Sources */,
 				A8318FDC1CF604D50015809A /* PlaygroundPage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1105,6 +1111,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5E08F29C201FEFE100ED74A2 /* CustomPlaygroundDisplayConvertible.swift in Sources */,
 				A8318FDD1CF604D50015809A /* PlaygroundPage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1113,6 +1120,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5E08F29D201FEFE100ED74A2 /* CustomPlaygroundDisplayConvertible.swift in Sources */,
 				A8318FDE1CF604D50015809A /* PlaygroundPage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PlaygroundSupport/PlaygroundSupport/CustomPlaygroundDisplayConvertible.swift
+++ b/PlaygroundSupport/PlaygroundSupport/CustomPlaygroundDisplayConvertible.swift
@@ -1,0 +1,56 @@
+//===--- CustomPlaygroundDisplayConvertible.swift -------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A type that supplies a custom description for playground logging.
+///
+/// All types have a default description for playgrounds. This protocol
+/// allows types to provide custom descriptions which are then logged in
+/// place of the original instance.
+///
+/// Playground logging can generate, at a minimum, a structured description
+/// of any type. Playground logging is also capable of generating a richer,
+/// more specialized description of core types -- for instance, the contents
+/// of a `String` are logged, as are the components of an `NSColor` or
+/// `UIColor`.
+///
+/// The current playground logging implementation logs specialized
+/// descriptions of at least the following types:
+///
+/// - `String` and `NSString`
+/// - `Int` and `UInt` (including the sized variants)
+/// - `Float` and `Double`
+/// - `Bool`
+/// - `Date` and `NSDate`
+/// - `NSAttributedString`
+/// - `NSNumber`
+/// - `NSRange`
+/// - `URL` and `NSURL`
+/// - `CGPoint`, `CGSize`, and `CGRect`
+/// - `NSColor`, `UIColor`, `CGColor`, and `CIColor`
+/// - `NSImage`, `UIImage`, `CGImage`, and `CIImage`
+/// - `NSBezierPath` and `UIBezierPath`
+/// - `NSView` and `UIView`
+///
+/// Playground logging may also be able to support specialized descriptions
+/// of other types.
+///
+/// Implementors of `CustomPlaygroundDisplayConvertible` may return a value of
+/// one of the above types to also receive a specialized log description.
+/// Implementors may also return any other type, and playground logging will
+/// generated structured logging for the returned value.
+public protocol CustomPlaygroundDisplayConvertible {
+    /// Returns the custom playground description for this instance.
+    ///
+    /// If this type has value semantics, the instance returned should be
+    /// unaffected by subsequent mutations if possible.
+    var playgroundDescription: Any { get }
+}


### PR DESCRIPTION
This new protocol is part of a [swift-evolution proposal](https://github.com/cwakamo/swift-evolution/blob/playground-quicklook-api-revamp/proposals/nnnn-playground-quicklook-api-revamp.md) to replace `PlaygroundQuickLook`/`CustomPlaygroundQuickLookable` with a new, PlaygroundSupport-vended protocol for customizing the display of instances in playgrounds.