### PR TITLE
[PlaygroundLogger] Use `prefix` and `suffix` when getting the first and last n children for structured log entries.

### DIFF
--- a/PlaygroundLogger/PlaygroundLogger/LogEntry+Reflection.swift
+++ b/PlaygroundLogger/PlaygroundLogger/LogEntry+Reflection.swift
@@ -222,17 +222,11 @@ extension Mirror {
                 numberOfChildren = count
             }
 
-            let start = children.startIndex
-            let max = children.index(start, offsetBy: numberOfChildren)
-
-            return superclassEntries + children[start..<max].map(logEntry(forChild:))
+            return superclassEntries + children.prefix(numberOfChildren).map(logEntry(forChild:))
         }
 
         func logEntries(forLastChildren count: Int) -> [LogEntry] {
-            let max = children.endIndex
-            let start = children.index(max, offsetBy: -count)
-
-            return children[start..<max].map(logEntry(forChild:))
+            return children.suffix(count).map(logEntry(forChild:))
         }
 
         // Ensure that our children are loggable (i.e. their depth is not prohibited by our current policy).

--- a/PlaygroundLogger/PlaygroundLoggerTests/LogEntryTests.swift
+++ b/PlaygroundLogger/PlaygroundLoggerTests/LogEntryTests.swift
@@ -92,7 +92,11 @@ class LogEntryTests: XCTestCase {
         }
 
         XCTAssertEqual(name, "set")
+
+        // We expect `totalChildrenCount` to be 1000 because `set` has 1000 elements.
         XCTAssertEqual(totalChildrenCount, 1000)
+
+        // We expect `children.count` to be 101 due to the default logging policy, which encodes the first 80 and the last 20 children when there's more than 100 children, plus a gap in between to indicate what was elided.
         XCTAssertEqual(children.count, 101)
 
         for (index, childEntry) in children.enumerated() {


### PR DESCRIPTION
Offsetting indices only works for collections which implement `BidirectionalCollection`, while `suffix(_:)` is available for all collections.
This prevent crashes when e.g. generating a `LogEntry` for instances of `Set`.

This addresses <rdar://problem/39791397>.