### PR TITLE
[PlaygroundLogger] Better handle encoding of empty images and views.

### DIFF
--- a/PlaygroundLogger/PlaygroundLogger/OpaqueRepresentations/AppKit/NSImage+OpaqueImageRepresentable.swift
+++ b/PlaygroundLogger/PlaygroundLogger/OpaqueRepresentations/AppKit/NSImage+OpaqueImageRepresentable.swift
@@ -34,7 +34,14 @@
 
         func encodeImage(into encoder: LogEncoder, withFormat format: LogEncoder.Format) throws {
             guard let bitmapRep = self.bestBitmapRepresentation else {
-                throw LoggingError.encodingFailure(reason: "Failed to get a bitmap representation of this NSImage")
+                if size == .zero {
+                    // If we couldn't get a bitmap representation because the image was empty, encode empty PNG data.
+                    encoder.encode(number: 0)
+                    return
+                }
+                else {
+                    throw LoggingError.encodingFailure(reason: "Failed to get a bitmap representation of this NSImage")
+                }
             }
 
             try bitmapRep.encodeImage(into: encoder, withFormat: format)

--- a/PlaygroundLogger/PlaygroundLogger/OpaqueRepresentations/AppKit/NSView+OpaqueImageRepresentable.swift
+++ b/PlaygroundLogger/PlaygroundLogger/OpaqueRepresentations/AppKit/NSView+OpaqueImageRepresentable.swift
@@ -16,7 +16,14 @@
     extension NSView: OpaqueImageRepresentable {
         func encodeImage(into encoder: LogEncoder, withFormat format: LogEncoder.Format) throws {
             guard let bitmapRep = self.bitmapImageRepForCachingDisplay(in: self.bounds) else {
-                throw LoggingError.encodingFailure(reason: "Unable to create a bitmap representation of this NSView")
+                if self.bounds == .zero {
+                    // If we couldn't get a bitmap representation because the view is zero-sized, encode empty PNG data.
+                    encoder.encode(number: 0)
+                    return
+                }
+                else {
+                    throw LoggingError.encodingFailure(reason: "Unable to create a bitmap representation of this NSView")
+                }
             }
 
             self.cacheDisplay(in: self.bounds, to: bitmapRep)

--- a/PlaygroundLogger/PlaygroundLogger/OpaqueRepresentations/UIKit/UIImage+OpaqueImageRepresentable.swift
+++ b/PlaygroundLogger/PlaygroundLogger/OpaqueRepresentations/UIKit/UIImage+OpaqueImageRepresentable.swift
@@ -16,7 +16,15 @@
     extension UIImage: OpaqueImageRepresentable {
         func encodeImage(into encoder: LogEncoder, withFormat format: LogEncoder.Format) throws {
             guard let pngData = UIImagePNGRepresentation(self) else {
-                throw LoggingError.encodingFailure(reason: "Failed to convert UIImage to PNG")
+                if size == .zero {
+                    // We tried encoding an empty image, so it understandably failed.
+                    // In this case, simply encode empty PNG data.
+                    encoder.encode(number: 0)
+                    return
+                }
+                else {
+                    throw LoggingError.encodingFailure(reason: "Failed to convert UIImage to PNG")
+                }
             }
 
             encoder.encode(number: UInt64(pngData.count))

--- a/PlaygroundLogger/PlaygroundLoggerTests/LogEntryTests.swift
+++ b/PlaygroundLogger/PlaygroundLoggerTests/LogEntryTests.swift
@@ -15,6 +15,12 @@ import XCTest
 
 import Foundation
 
+#if os(macOS)
+    import AppKit
+#elseif os(iOS) || os(tvOS)
+    import UIKit
+#endif
+
 class LogEntryTests: XCTestCase {
     func testNilIUO() throws {
         let nilIUO: Int! = nil
@@ -29,5 +35,49 @@ class LogEntryTests: XCTestCase {
         XCTAssertEqual(name, "nilIUO")
         XCTAssertEqual(totalChildrenCount, 0)
         XCTAssert(children.isEmpty)
+    }
+
+    func testEmptyView() throws {
+        #if os(macOS)
+            let emptyView = NSView()
+        #elseif os(iOS) || os(tvOS)
+            let emptyView = UIView()
+        #endif
+
+        let logEntry = try LogEntry(describing: emptyView, name: "emptyView", policy: .default)
+
+        guard case let .opaque(name, _, _, _, representation) = logEntry else {
+            XCTFail("Expected an opaque log entry")
+            return
+        }
+
+        XCTAssertEqual(name, "emptyView")
+        XCTAssert(representation is ImageOpaqueRepresentation)
+
+        // Try to encode the log entry. This operation shouldn't throw; if it does, it will fail the test.
+        let encoder = LogEncoder()
+        try logEntry.encode(with: encoder, format: .current)
+    }
+
+    func testEmptyImage() throws {
+        #if os(macOS)
+            let emptyImage = NSImage()
+        #elseif os(iOS) || os(tvOS)
+            let emptyImage = UIImage()
+        #endif
+
+        let logEntry = try LogEntry(describing: emptyImage, name: "emptyImage", policy: .default)
+
+        guard case let .opaque(name, _, _, _, representation) = logEntry else {
+            XCTFail("Expected an opaque log entry")
+            return
+        }
+
+        XCTAssertEqual(name, "emptyImage")
+        XCTAssert(representation is ImageOpaqueRepresentation)
+
+        // Try to encode the log entry. This operation shouldn't throw; if it does, it will fail the test.
+        let encoder = LogEncoder()
+        try logEntry.encode(with: encoder, format: .current)
     }
 }


### PR DESCRIPTION
If a `NSView`, `NSImage`, or `UIImage` was zero-sized (e.g. 0x0), PlaygroundLogger would fail to encode this because it couldn't get a bitmap representation for the image.
Instead, handle this case specially, and instead of failing, send zero bytes of PNG data. Xcode renders this as an empty image, which is the expectation for this case.
This commit includes tests that empty views and images on all platforms generate image representations which can be encoded without throwing any errors.

This is an improvement over the legacy PlaygroundLogger implementation, which would render these plus empty `UIView` instances as if they were the string "empty image".

This addresses <rdar://problem/40207604>.