### PR TITLE
[PlaygroundLogger] Add checks in the logger entrypoints to prevent recursive logging.

### DIFF
--- a/PlaygroundLogger/PlaygroundLogger.xcodeproj/project.pbxproj
+++ b/PlaygroundLogger/PlaygroundLogger.xcodeproj/project.pbxproj
@@ -82,6 +82,12 @@
 		5E5D77842040F5E900EBC3A9 /* LoggingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5D77832040F5E900EBC3A9 /* LoggingError.swift */; };
 		5E5F600B20409D4E007EF0A8 /* LogPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5F600A20409D4E007EF0A8 /* LogPolicy.swift */; };
 		5E5FE50B202D13C800E28C3C /* PGLConcurrentMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5FE50A202D13C800E28C3C /* PGLConcurrentMap.swift */; };
+		5EB651C0213A01D0001CC984 /* LegacyEntrypointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EB651BF213A01D0001CC984 /* LegacyEntrypointTests.swift */; };
+		5EB651C1213A01D0001CC984 /* LegacyEntrypointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EB651BF213A01D0001CC984 /* LegacyEntrypointTests.swift */; };
+		5EB651C2213A01D0001CC984 /* LegacyEntrypointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EB651BF213A01D0001CC984 /* LegacyEntrypointTests.swift */; };
+		5EB651C4213A081A001CC984 /* LoggerEntrypointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EB651C3213A081A001CC984 /* LoggerEntrypointTests.swift */; };
+		5EB651C5213A081A001CC984 /* LoggerEntrypointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EB651C3213A081A001CC984 /* LoggerEntrypointTests.swift */; };
+		5EB651C6213A081A001CC984 /* LoggerEntrypointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EB651C3213A081A001CC984 /* LoggerEntrypointTests.swift */; };
 		5ECE8F911FFCD2A70034D9BC /* LegacyPlaygroundLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ECE8F901FFCD2A70034D9BC /* LegacyPlaygroundLoggerTests.swift */; };
 		5EE3867420352F3200D625F0 /* CGFloat+CustomOpaqueLoggable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EE3867320352F3200D625F0 /* CGFloat+CustomOpaqueLoggable.swift */; };
 		5EF581532041387C00AC14FE /* CustomPlaygroundDisplayConvertibleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF581512041384700AC14FE /* CustomPlaygroundDisplayConvertibleTests.swift */; };
@@ -262,6 +268,8 @@
 		5E5D77832040F5E900EBC3A9 /* LoggingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingError.swift; sourceTree = "<group>"; };
 		5E5F600A20409D4E007EF0A8 /* LogPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogPolicy.swift; sourceTree = "<group>"; };
 		5E5FE50A202D13C800E28C3C /* PGLConcurrentMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PGLConcurrentMap.swift; sourceTree = "<group>"; };
+		5EB651BF213A01D0001CC984 /* LegacyEntrypointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyEntrypointTests.swift; sourceTree = "<group>"; };
+		5EB651C3213A081A001CC984 /* LoggerEntrypointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerEntrypointTests.swift; sourceTree = "<group>"; };
 		5ECE8F901FFCD2A70034D9BC /* LegacyPlaygroundLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyPlaygroundLoggerTests.swift; sourceTree = "<group>"; };
 		5EE3867320352F3200D625F0 /* CGFloat+CustomOpaqueLoggable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGFloat+CustomOpaqueLoggable.swift"; sourceTree = "<group>"; };
 		5EF581512041384700AC14FE /* CustomPlaygroundDisplayConvertibleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPlaygroundDisplayConvertibleTests.swift; sourceTree = "<group>"; };
@@ -405,6 +413,8 @@
 				5EF581512041384700AC14FE /* CustomPlaygroundDisplayConvertibleTests.swift */,
 				5E48E0A92042925B00C7712D /* LogEntryTests.swift */,
 				5E5D777F2040BD7D00EBC3A9 /* LogPolicyTests.swift */,
+				5EB651C3213A081A001CC984 /* LoggerEntrypointTests.swift */,
+				5EB651BF213A01D0001CC984 /* LegacyEntrypointTests.swift */,
 				5ECE8F901FFCD2A70034D9BC /* LegacyPlaygroundLoggerTests.swift */,
 			);
 			path = PlaygroundLoggerTests;
@@ -980,6 +990,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5EB651C0213A01D0001CC984 /* LegacyEntrypointTests.swift in Sources */,
+				5EB651C4213A081A001CC984 /* LoggerEntrypointTests.swift in Sources */,
 				5E5D77802040BD7D00EBC3A9 /* LogPolicyTests.swift in Sources */,
 				5E48E0AA2042925B00C7712D /* LogEntryTests.swift in Sources */,
 				5EF581532041387C00AC14FE /* CustomPlaygroundDisplayConvertibleTests.swift in Sources */,
@@ -991,6 +1003,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5EB651C1213A01D0001CC984 /* LegacyEntrypointTests.swift in Sources */,
+				5EB651C5213A081A001CC984 /* LoggerEntrypointTests.swift in Sources */,
 				5E5D77812040BD7D00EBC3A9 /* LogPolicyTests.swift in Sources */,
 				5E48E0AB2042925B00C7712D /* LogEntryTests.swift in Sources */,
 				5EF581542041387C00AC14FE /* CustomPlaygroundDisplayConvertibleTests.swift in Sources */,
@@ -1020,6 +1034,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5EB651C2213A01D0001CC984 /* LegacyEntrypointTests.swift in Sources */,
+				5EB651C6213A081A001CC984 /* LoggerEntrypointTests.swift in Sources */,
 				5E5D77822040BD7D00EBC3A9 /* LogPolicyTests.swift in Sources */,
 				5E48E0AC2042925B00C7712D /* LogEntryTests.swift in Sources */,
 				5EF581552041387C00AC14FE /* CustomPlaygroundDisplayConvertibleTests.swift in Sources */,

--- a/PlaygroundLogger/PlaygroundLogger.xcodeproj/project.pbxproj
+++ b/PlaygroundLogger/PlaygroundLogger.xcodeproj/project.pbxproj
@@ -93,6 +93,8 @@
 		5EF6403E204148B80007BDD2 /* NSBezierPath+PGLKeyedArchivingUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 5EF6403C204148B80007BDD2 /* NSBezierPath+PGLKeyedArchivingUtilities.m */; settings = {COMPILER_FLAGS = "-fobjc-arc-exceptions"; }; };
 		5EF64041204149DE0007BDD2 /* UIBezierPath+PGLKeyedArchivingUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 5EF6403F204149DE0007BDD2 /* UIBezierPath+PGLKeyedArchivingUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5EF64042204149DE0007BDD2 /* UIBezierPath+PGLKeyedArchivingUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 5EF64040204149DE0007BDD2 /* UIBezierPath+PGLKeyedArchivingUtilities.m */; settings = {COMPILER_FLAGS = "-fobjc-arc-exceptions"; }; };
+		5EFB2A5321211BC300BA43D3 /* PGLThreadIsLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 5EFB2A5121211BC300BA43D3 /* PGLThreadIsLogging.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5EFB2A5421211BC300BA43D3 /* PGLThreadIsLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = 5EFB2A5221211BC300BA43D3 /* PGLThreadIsLogging.m */; };
 		5EFE9193203F6CF900E21BAA /* LegacyPlaygroundLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ECE8F901FFCD2A70034D9BC /* LegacyPlaygroundLoggerTests.swift */; };
 		5EFE919B203F6DD700E21BAA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EFE919A203F6DD700E21BAA /* AppDelegate.swift */; };
 		5EFE919D203F6DD700E21BAA /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EFE919C203F6DD700E21BAA /* ViewController.swift */; };
@@ -269,6 +271,8 @@
 		5EF6403C204148B80007BDD2 /* NSBezierPath+PGLKeyedArchivingUtilities.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSBezierPath+PGLKeyedArchivingUtilities.m"; sourceTree = "<group>"; };
 		5EF6403F204149DE0007BDD2 /* UIBezierPath+PGLKeyedArchivingUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIBezierPath+PGLKeyedArchivingUtilities.h"; sourceTree = "<group>"; };
 		5EF64040204149DE0007BDD2 /* UIBezierPath+PGLKeyedArchivingUtilities.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIBezierPath+PGLKeyedArchivingUtilities.m"; sourceTree = "<group>"; };
+		5EFB2A5121211BC300BA43D3 /* PGLThreadIsLogging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PGLThreadIsLogging.h; sourceTree = "<group>"; };
+		5EFB2A5221211BC300BA43D3 /* PGLThreadIsLogging.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PGLThreadIsLogging.m; sourceTree = "<group>"; };
 		5EFE9189203F6CC400E21BAA /* PlaygroundLoggerTests_iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PlaygroundLoggerTests_iOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5EFE918D203F6CC400E21BAA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		5EFE9198203F6DD700E21BAA /* PlaygroundLoggerTestHost_iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PlaygroundLoggerTestHost_iOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -354,6 +358,7 @@
 				5EFE91B1203F6E8D00E21BAA /* PlaygroundLoggerTestHost_tvOS */,
 				5E11805820414E0C00B73EE9 /* Config Files */,
 				5E2646281FB64876002DC6B6 /* Products */,
+				5EFB2A352121145E00BA43D3 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -599,8 +604,17 @@
 				5E184716202BB80200F01AD1 /* PGLConcurrentMap.h */,
 				5E184717202BB80200F01AD1 /* PGLConcurrentMap_MRR.m */,
 				5E5FE50A202D13C800E28C3C /* PGLConcurrentMap.swift */,
+				5EFB2A5121211BC300BA43D3 /* PGLThreadIsLogging.h */,
+				5EFB2A5221211BC300BA43D3 /* PGLThreadIsLogging.m */,
 			);
 			path = Utilities;
+			sourceTree = "<group>";
+		};
+		5EFB2A352121145E00BA43D3 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		5EFE918A203F6CC400E21BAA /* PlaygroundLoggerTests_iOS */ = {
@@ -651,6 +665,7 @@
 			files = (
 				5E184718202BB80200F01AD1 /* PGLConcurrentMap.h in Headers */,
 				5EF64041204149DE0007BDD2 /* UIBezierPath+PGLKeyedArchivingUtilities.h in Headers */,
+				5EFB2A5321211BC300BA43D3 /* PGLThreadIsLogging.h in Headers */,
 				5EF6403D204148B80007BDD2 /* NSBezierPath+PGLKeyedArchivingUtilities.h in Headers */,
 				5EF64039204145A80007BDD2 /* NSAttributedString+PGLKeyedArchivingUtilities.h in Headers */,
 				5E2646381FB64876002DC6B6 /* PlaygroundLogger.h in Headers */,
@@ -778,7 +793,7 @@
 		5E26461E1FB64876002DC6B6 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0930;
+				LastSwiftUpdateCheck = 1000;
 				LastUpgradeCheck = 0910;
 				ORGANIZATIONNAME = "Apple Inc. and the Swift project authors";
 				TargetAttributes = {
@@ -952,6 +967,7 @@
 				5E2755CF1FB657F200B69C83 /* LogEntry.swift in Sources */,
 				5E2756221FC4873000B69C83 /* UInt64+TaggedOpaqueRepresentation.swift in Sources */,
 				5E2756281FC4895100B69C83 /* Double+TaggedOpaqueRepresentation.swift in Sources */,
+				5EFB2A5421211BC300BA43D3 /* PGLThreadIsLogging.m in Sources */,
 				5E2756481FC4DE1500B69C83 /* NSView+OpaqueImageRepresentable.swift in Sources */,
 				5E2755D31FB672DC00B69C83 /* SendData.swift in Sources */,
 				5E27567E1FCF429900B69C83 /* NSCursor+CustomOpaqueLoggable.swift in Sources */,

--- a/PlaygroundLogger/PlaygroundLogger/LegacySupport/LegacyEntrypoints.swift
+++ b/PlaygroundLogger/PlaygroundLogger/LegacySupport/LegacyEntrypoints.swift
@@ -35,7 +35,11 @@ fileprivate func legacySendDataStub(_: NSData) -> Void {
 }
 
 @_silgen_name("playground_log_hidden")
-public func legacyLog<T>(instance: T, name: String, id: Int, startLine: Int, endLine: Int, startColumn: Int, endColumn: Int) -> AnyObject {
+public func legacyLog<T>(instance: T, name: String, id: Int, startLine: Int, endLine: Int, startColumn: Int, endColumn: Int) -> AnyObject? {
+    guard !PGLThreadIsLogging else { return nil }
+    PGLThreadIsLogging = true
+    defer { PGLThreadIsLogging = false }
+    
     let packet = LogPacket(describingResult: instance, named: name, withPolicy: .default, startLine: startLine, endLine: endLine, startColumn: startColumn, endColumn: endColumn)
 
     let data: Data
@@ -68,7 +72,11 @@ public func legacyLog<T>(instance: T, name: String, id: Int, startLine: Int, end
 }
 
 @_silgen_name ("playground_log_scope_entry")
-public func legacyLogScopeEntry(startLine: Int, endLine: Int, startColumn: Int, endColumn: Int) -> AnyObject {
+public func legacyLogScopeEntry(startLine: Int, endLine: Int, startColumn: Int, endColumn: Int) -> AnyObject? {
+    guard !PGLThreadIsLogging else { return nil }
+    PGLThreadIsLogging = true
+    defer { PGLThreadIsLogging = false }
+    
     let packet = LogPacket(scopeEntryWithStartLine: startLine, endLine: endLine, startColumn: startColumn, endColumn: endColumn)
 
     // Encoding a scope entry packet should not fail under any circumstances.
@@ -78,7 +86,11 @@ public func legacyLogScopeEntry(startLine: Int, endLine: Int, startColumn: Int, 
 }
 
 @_silgen_name ("playground_log_scope_exit")
-public func legacyLogScopeExit(startLine: Int, endLine: Int, startColumn: Int, endColumn: Int) -> AnyObject {
+public func legacyLogScopeExit(startLine: Int, endLine: Int, startColumn: Int, endColumn: Int) -> AnyObject? {
+    guard !PGLThreadIsLogging else { return nil }
+    PGLThreadIsLogging = true
+    defer { PGLThreadIsLogging = false }
+    
     let packet = LogPacket(scopeExitWithStartLine: startLine, endLine: endLine, startColumn: startColumn, endColumn: endColumn)
 
     // Encoding a scope exit packet should not fail under any circumstances.
@@ -88,7 +100,11 @@ public func legacyLogScopeExit(startLine: Int, endLine: Int, startColumn: Int, e
 }
 
 @_silgen_name ("playground_log_postprint")
-public func legacyLogPostPrint(startLine: Int, endLine: Int, startColumn: Int, endColumn: Int) -> AnyObject {
+public func legacyLogPostPrint(startLine: Int, endLine: Int, startColumn: Int, endColumn: Int) -> AnyObject? {
+    guard !PGLThreadIsLogging else { return nil }
+    PGLThreadIsLogging = true
+    defer { PGLThreadIsLogging = false }
+    
     let printedString = Thread.current.threadDictionary[printedStringThreadDictionaryKey] as! String? ?? ""
     
     Thread.current.threadDictionary.removeObject(forKey: printedStringThreadDictionaryKey)

--- a/PlaygroundLogger/PlaygroundLogger/LegacySupport/LegacyEntrypoints.swift
+++ b/PlaygroundLogger/PlaygroundLogger/LegacySupport/LegacyEntrypoints.swift
@@ -36,9 +36,9 @@ fileprivate func legacySendDataStub(_: NSData) -> Void {
 
 @_silgen_name("playground_log_hidden")
 public func legacyLog<T>(instance: T, name: String, id: Int, startLine: Int, endLine: Int, startColumn: Int, endColumn: Int) -> AnyObject? {
-    guard !PGLThreadIsLogging else { return nil }
-    PGLThreadIsLogging = true
-    defer { PGLThreadIsLogging = false }
+    guard !PGLGetThreadIsLogging() else { return nil }
+    PGLSetThreadIsLogging(true)
+    defer { PGLSetThreadIsLogging(false) }
     
     let packet = LogPacket(describingResult: instance, named: name, withPolicy: .default, startLine: startLine, endLine: endLine, startColumn: startColumn, endColumn: endColumn)
 
@@ -73,9 +73,9 @@ public func legacyLog<T>(instance: T, name: String, id: Int, startLine: Int, end
 
 @_silgen_name ("playground_log_scope_entry")
 public func legacyLogScopeEntry(startLine: Int, endLine: Int, startColumn: Int, endColumn: Int) -> AnyObject? {
-    guard !PGLThreadIsLogging else { return nil }
-    PGLThreadIsLogging = true
-    defer { PGLThreadIsLogging = false }
+    guard !PGLGetThreadIsLogging() else { return nil }
+    PGLSetThreadIsLogging(true)
+    defer { PGLSetThreadIsLogging(false) }
     
     let packet = LogPacket(scopeEntryWithStartLine: startLine, endLine: endLine, startColumn: startColumn, endColumn: endColumn)
 
@@ -87,9 +87,9 @@ public func legacyLogScopeEntry(startLine: Int, endLine: Int, startColumn: Int, 
 
 @_silgen_name ("playground_log_scope_exit")
 public func legacyLogScopeExit(startLine: Int, endLine: Int, startColumn: Int, endColumn: Int) -> AnyObject? {
-    guard !PGLThreadIsLogging else { return nil }
-    PGLThreadIsLogging = true
-    defer { PGLThreadIsLogging = false }
+    guard !PGLGetThreadIsLogging() else { return nil }
+    PGLSetThreadIsLogging(true)
+    defer { PGLSetThreadIsLogging(false) }
     
     let packet = LogPacket(scopeExitWithStartLine: startLine, endLine: endLine, startColumn: startColumn, endColumn: endColumn)
 
@@ -101,9 +101,9 @@ public func legacyLogScopeExit(startLine: Int, endLine: Int, startColumn: Int, e
 
 @_silgen_name ("playground_log_postprint")
 public func legacyLogPostPrint(startLine: Int, endLine: Int, startColumn: Int, endColumn: Int) -> AnyObject? {
-    guard !PGLThreadIsLogging else { return nil }
-    PGLThreadIsLogging = true
-    defer { PGLThreadIsLogging = false }
+    guard !PGLGetThreadIsLogging() else { return nil }
+    PGLSetThreadIsLogging(true)
+    defer { PGLSetThreadIsLogging(false) }
     
     let printedString = Thread.current.threadDictionary[printedStringThreadDictionaryKey] as! String? ?? ""
     

--- a/PlaygroundLogger/PlaygroundLogger/LoggerEntrypoints.swift
+++ b/PlaygroundLogger/PlaygroundLogger/LoggerEntrypoints.swift
@@ -19,6 +19,10 @@ func logResult(_ result: Any,
                endLine: Int,
                startColumn: Int,
                endColumn: Int) {
+    guard !PGLThreadIsLogging else { return }
+    PGLThreadIsLogging = true
+    defer { PGLThreadIsLogging = false }
+    
     let packet = LogPacket(describingResult: result, named: name, withPolicy: .default, startLine: startLine, endLine: endLine, startColumn: startColumn, endColumn: endColumn)
     
     let data: Data
@@ -54,6 +58,10 @@ func logScopeEntry(startLine: Int,
                    endLine: Int,
                    startColumn: Int,
                    endColumn: Int) {
+    guard !PGLThreadIsLogging else { return }
+    PGLThreadIsLogging = true
+    defer { PGLThreadIsLogging = false }
+    
     let packet = LogPacket(scopeEntryWithStartLine: startLine, endLine: endLine, startColumn: startColumn, endColumn: endColumn)
 
     // Encoding a scope entry packet should not fail under any circumstances.
@@ -66,6 +74,10 @@ func logScopeExit(startLine: Int,
                   endLine: Int,
                   startColumn: Int,
                   endColumn: Int) {
+    guard !PGLThreadIsLogging else { return }
+    PGLThreadIsLogging = true
+    defer { PGLThreadIsLogging = false }
+    
     let packet = LogPacket(scopeExitWithStartLine: startLine, endLine: endLine, startColumn: startColumn, endColumn: endColumn)
 
     // Encoding a scope exit packet should not fail under any circumstances.
@@ -77,6 +89,9 @@ func logScopeExit(startLine: Int,
 let printedStringThreadDictionaryKey: NSString = "org.swift.PlaygroundLogger.printedString"
 
 func printHook(string: String) {
+    // Don't store the printed string if we're already logging elsewhere in this thread.
+    guard !PGLThreadIsLogging else { return }
+    
     Thread.current.threadDictionary[printedStringThreadDictionaryKey] = string as NSString
 }
 
@@ -84,6 +99,10 @@ func logPostPrint(startLine: Int,
                   endLine: Int,
                   startColumn: Int,
                   endColumn: Int) {
+    guard !PGLThreadIsLogging else { return }
+    PGLThreadIsLogging = true
+    defer { PGLThreadIsLogging = false }
+    
     guard let printedString = Thread.current.threadDictionary[printedStringThreadDictionaryKey] as! String? else {
         return
     }

--- a/PlaygroundLogger/PlaygroundLogger/LoggerEntrypoints.swift
+++ b/PlaygroundLogger/PlaygroundLogger/LoggerEntrypoints.swift
@@ -19,9 +19,9 @@ func logResult(_ result: Any,
                endLine: Int,
                startColumn: Int,
                endColumn: Int) {
-    guard !PGLThreadIsLogging else { return }
-    PGLThreadIsLogging = true
-    defer { PGLThreadIsLogging = false }
+    guard !PGLGetThreadIsLogging() else { return }
+    PGLSetThreadIsLogging(true)
+    defer { PGLSetThreadIsLogging(false) }
     
     let packet = LogPacket(describingResult: result, named: name, withPolicy: .default, startLine: startLine, endLine: endLine, startColumn: startColumn, endColumn: endColumn)
     
@@ -58,9 +58,9 @@ func logScopeEntry(startLine: Int,
                    endLine: Int,
                    startColumn: Int,
                    endColumn: Int) {
-    guard !PGLThreadIsLogging else { return }
-    PGLThreadIsLogging = true
-    defer { PGLThreadIsLogging = false }
+    guard !PGLGetThreadIsLogging() else { return }
+    PGLSetThreadIsLogging(true)
+    defer { PGLSetThreadIsLogging(false) }
     
     let packet = LogPacket(scopeEntryWithStartLine: startLine, endLine: endLine, startColumn: startColumn, endColumn: endColumn)
 
@@ -74,9 +74,9 @@ func logScopeExit(startLine: Int,
                   endLine: Int,
                   startColumn: Int,
                   endColumn: Int) {
-    guard !PGLThreadIsLogging else { return }
-    PGLThreadIsLogging = true
-    defer { PGLThreadIsLogging = false }
+    guard !PGLGetThreadIsLogging() else { return }
+    PGLSetThreadIsLogging(true)
+    defer { PGLSetThreadIsLogging(false) }
     
     let packet = LogPacket(scopeExitWithStartLine: startLine, endLine: endLine, startColumn: startColumn, endColumn: endColumn)
 
@@ -90,7 +90,7 @@ let printedStringThreadDictionaryKey: NSString = "org.swift.PlaygroundLogger.pri
 
 func printHook(string: String) {
     // Don't store the printed string if we're already logging elsewhere in this thread.
-    guard !PGLThreadIsLogging else { return }
+    guard !PGLGetThreadIsLogging() else { return }
     
     Thread.current.threadDictionary[printedStringThreadDictionaryKey] = string as NSString
 }
@@ -99,9 +99,9 @@ func logPostPrint(startLine: Int,
                   endLine: Int,
                   startColumn: Int,
                   endColumn: Int) {
-    guard !PGLThreadIsLogging else { return }
-    PGLThreadIsLogging = true
-    defer { PGLThreadIsLogging = false }
+    guard !PGLGetThreadIsLogging() else { return }
+    PGLSetThreadIsLogging(true)
+    defer { PGLSetThreadIsLogging(false) }
     
     guard let printedString = Thread.current.threadDictionary[printedStringThreadDictionaryKey] as! String? else {
         return

--- a/PlaygroundLogger/PlaygroundLogger/PlaygroundLogger.h
+++ b/PlaygroundLogger/PlaygroundLogger/PlaygroundLogger.h
@@ -19,6 +19,7 @@ FOUNDATION_EXPORT double PlaygroundLoggerVersionNumber;
 FOUNDATION_EXPORT const unsigned char PlaygroundLoggerVersionString[];
 
 #import <PlaygroundLogger/PGLConcurrentMap.h>
+#import <PlaygroundLogger/PGLThreadIsLogging.h>
 
 #import <PlaygroundLogger/NSAttributedString+PGLKeyedArchivingUtilities.h>
 #import <PlaygroundLogger/NSBezierPath+PGLKeyedArchivingUtilities.h>

--- a/PlaygroundLogger/PlaygroundLogger/SendData.swift
+++ b/PlaygroundLogger/PlaygroundLogger/SendData.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-fileprivate func unsetSendData(_: NSData) {
+internal /*testable*/ func unsetSendData(_: NSData) {
     fatalError("PlaygroundLogger not initialized")
 }
 

--- a/PlaygroundLogger/PlaygroundLogger/Utilities/PGLThreadIsLogging.h
+++ b/PlaygroundLogger/PlaygroundLogger/Utilities/PGLThreadIsLogging.h
@@ -24,4 +24,14 @@ __BEGIN_DECLS
 /// themselves logged.
 extern __thread bool PGLThreadIsLogging;
 
+/// A helper function to get the value of `PGLThreadIsLogging` safely from Swift.
+static inline bool PGLGetThreadIsLogging(void) {
+    return PGLThreadIsLogging;
+}
+
+/// A helper function to set the value of `PGLThreadIsLogging` safely from Swift.
+static inline void PGLSetThreadIsLogging(bool threadIsLogging) {
+    PGLThreadIsLogging = threadIsLogging;
+}
+
 __END_DECLS

--- a/PlaygroundLogger/PlaygroundLogger/Utilities/PGLThreadIsLogging.h
+++ b/PlaygroundLogger/PlaygroundLogger/Utilities/PGLThreadIsLogging.h
@@ -1,0 +1,27 @@
+//===--- PGLThreadIsLogging.h ---------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#import <sys/cdefs.h>
+#import <stdbool.h>
+
+__BEGIN_DECLS
+
+/// A thread-local `bool` which indicates whether or not the current thread is
+/// logging.
+///
+/// This is used by the functions in LoggerEntrypoints.swift and
+/// LegacyEntrypoints.swift to prevent generating log packets while in already
+/// generating a log packet. It means the side-effects of logging are not
+/// themselves logged.
+extern __thread bool PGLThreadIsLogging;
+
+__END_DECLS

--- a/PlaygroundLogger/PlaygroundLogger/Utilities/PGLThreadIsLogging.h
+++ b/PlaygroundLogger/PlaygroundLogger/Utilities/PGLThreadIsLogging.h
@@ -19,7 +19,7 @@ __BEGIN_DECLS
 /// logging.
 ///
 /// This is used by the functions in LoggerEntrypoints.swift and
-/// LegacyEntrypoints.swift to prevent generating log packets while in already
+/// LegacyEntrypoints.swift to prevent generating log packets while already
 /// generating a log packet. It means the side-effects of logging are not
 /// themselves logged.
 extern __thread bool PGLThreadIsLogging;

--- a/PlaygroundLogger/PlaygroundLogger/Utilities/PGLThreadIsLogging.m
+++ b/PlaygroundLogger/PlaygroundLogger/Utilities/PGLThreadIsLogging.m
@@ -1,0 +1,15 @@
+//===--- PGLThreadIsLogging.m ---------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#import <PlaygroundLogger/PGLThreadIsLogging.h>
+
+__thread bool PGLThreadIsLogging = false;

--- a/PlaygroundLogger/PlaygroundLoggerTests/LegacyEntrypointTests.swift
+++ b/PlaygroundLogger/PlaygroundLoggerTests/LegacyEntrypointTests.swift
@@ -1,0 +1,43 @@
+//===--- LegacyEntrypointTests.swift --------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+@testable import PlaygroundLogger
+
+class LegacyEntrypointTests: XCTestCase {
+    func testRecursiveLogging() {
+        // Create a struct which, as a side effect of being logged, tries to log itself.
+        // This is representative of a playground where `self` is logged in places like a CustomStringConvertible conformance.
+        struct Struct: CustomStringConvertible {
+            let x: Int
+            let y: Int
+            
+            var description: String {
+                // This direct call to the logger mirrors what would happen if this property were instrumented by the playground logger and there were a bare reference to `self`.
+                let logData = legacyLog(instance: self, name: "self", id: 0, startLine: 1, endLine: 1, startColumn: 1, endColumn: 1)
+
+                // Since `description` is only ever called by logging, we can assert that we have nil.
+                // If we called `description` by other means we'd need to vary this assertion to match.
+                XCTAssertNil(logData)
+
+                return "(\(x), \(y))"
+            }
+        }
+
+        let subject = Struct(x: 0, y: 0)
+
+        // Log an instance of `Struct`. This should succeed (i.e. return data).
+        let logData = legacyLog(instance: subject, name: "subject", id: 0, startLine: 1, endLine: 1, startColumn: 1, endColumn: 1)
+
+        XCTAssertNotNil(logData)
+    }
+}

--- a/PlaygroundLogger/PlaygroundLoggerTests/LoggerEntrypointTests.swift
+++ b/PlaygroundLogger/PlaygroundLoggerTests/LoggerEntrypointTests.swift
@@ -1,0 +1,72 @@
+//===--- LoggerEntrypointTests.swift --------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+@testable import PlaygroundLogger
+
+fileprivate var numberOfDataSent: Int = 0
+
+fileprivate func countData(_: NSData) -> Void {
+    numberOfDataSent += 1
+}
+
+class LoggerEntrypointTests: XCTestCase {
+    override class func setUp() {
+        super.setUp()
+
+        // Tell PlaygroundLogger to use our function for counting data.
+        PlaygroundLogger.sendData = countData
+    }
+
+    override class func tearDown() {
+        super.tearDown()
+
+        // Reset PlaygroundLogger.
+        PlaygroundLogger.sendData = unsetSendData
+    }
+
+    override func setUp() {
+        // Reset the data counter.
+        numberOfDataSent = 0
+
+        super.setUp()
+    }
+
+    func testRecursiveLogging() {
+        // Create a struct which, as a side effect of being logged, tries to log itself.
+        // This is representative of a playground where `self` is logged in places like a CustomStringConvertible conformance.
+        struct Struct: CustomStringConvertible {
+            let x: Int
+            let y: Int
+
+            var description: String {
+                // Capture the previous number of data sent so we can check against it later.
+                let previousNumberOfDataSent = numberOfDataSent
+
+                // This direct call to the logger mirrors what would happen if this property were instrumented by the playground logger and there were a bare reference to `self`.
+                PlaygroundLogger.logResult(self, named: "self", withIdentifier: 0, startLine: 1, endLine: 1, startColumn: 1, endColumn: 1)
+
+                // Since `description` is only ever called by logging, we can assert that no additional data was sent.
+                // If we called `description` by other means we'd need to vary this assertion to match.
+                XCTAssertEqual(previousNumberOfDataSent, numberOfDataSent, "We don't expect any more data to be sent by that previous log line!")
+
+                return "(\(x), \(y))"
+            }
+        }
+
+        let subject = Struct(x: 0, y: 0)
+
+        PlaygroundLogger.logResult(subject, named: "subject", withIdentifier: 0, startLine: 1, endLine: 1, startColumn: 1, endColumn: 1)
+
+        XCTAssertEqual(numberOfDataSent, 1, "We expect only one data to be sent over the course of this test")
+    }
+}


### PR DESCRIPTION
The logger entrypoints now consult a C-defined thread-local `bool` and exit immediately if the current thread is already logging. If the current thread is not logging, they set the `bool` to indicate that it is, and then unset it at the end of the function.

This allows types which reference `self` in their implementations of `CustomPlaygroundQuickLookable` or `CustomStringConvertible` (among other things) in such a way that `self` would be logged to not cause infinite recursion in the logger. It also means that logging won't log the side-effects of logging anymore.

This addresses <rdar://problem/41460357> / SR-8349.