### PR TITLE
[PlaygroundLogger] Make NSView and UIView logging short-circuit if no…

### DIFF
--- a/PlaygroundLogger/PlaygroundLogger/OpaqueRepresentations/AppKit/NSView+OpaqueImageRepresentable.swift
+++ b/PlaygroundLogger/PlaygroundLogger/OpaqueRepresentations/AppKit/NSView+OpaqueImageRepresentable.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2017-2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -15,6 +15,12 @@
     
     extension NSView: OpaqueImageRepresentable {
         func encodeImage(into encoder: LogEncoder, withFormat format: LogEncoder.Format) throws {
+            guard Thread.isMainThread else {
+                // If we're not on the main thread, then just encode empty PNG data.
+                encoder.encode(number: 0)
+                return
+            }
+
             guard let bitmapRep = self.bitmapImageRepForCachingDisplay(in: self.bounds) else {
                 if self.bounds == .zero {
                     // If we couldn't get a bitmap representation because the view is zero-sized, encode empty PNG data.

--- a/PlaygroundLogger/PlaygroundLogger/OpaqueRepresentations/UIKit/UIView+OpaqueImageRepresentable.swift
+++ b/PlaygroundLogger/PlaygroundLogger/OpaqueRepresentations/UIKit/UIView+OpaqueImageRepresentable.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2017-2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2017-2019 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -15,6 +15,12 @@
     
     extension UIView: OpaqueImageRepresentable {
         func encodeImage(into encoder: LogEncoder, withFormat format: LogEncoder.Format) {
+            guard Thread.isMainThread else {
+                // If we're not on the main thread, then just encode empty PNG data.
+                encoder.encode(number: 0)
+                return
+            }
+
             let ir = UIGraphicsImageRenderer(size: bounds.size)
             let pngData = ir.pngData { _ in
                 self.drawHierarchy(in: bounds, afterScreenUpdates: true)


### PR DESCRIPTION
…t on the main thread.

It's not safe to render a snapshot of an `NSView` or `UIView` on a background thread.
As a result, when encoding an `{NS,UI}View`-based opaque image representation, short-circuit and encode empty PNG data if on a background thread.

This addresses <rdar://problem/46579594>.