### PR TITLE
Fixed broken legacy documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ PlaygroundSupport offers a limited set of APIs for communicating specific
 requests to Xcode and should be self-explanatory.
 
 PlaygroundLogger is more complex and includes documentation on the API in
-[PlaygroundLogger/Documentation/LoggerAPI.md](PlaygroundLogger/Documentation/LoggerAPI.md)
+[Legacy/PlaygroundLogger/Documentation/LoggerAPI.md](Legacy/PlaygroundLogger/Documentation/LoggerAPI.md)
 and communication format in
-[PlaygroundLogger/Documentation/LoggerFormat.md](PlaygroundLogger/Documentation/LoggerFormat.md).
+[Legacy/PlaygroundLogger/Documentation/LoggerFormat.md](Legacy/PlaygroundLogger/Documentation/LoggerFormat.md).
 
 ## Working with Xcode Playground Support
 


### PR DESCRIPTION
Following two links were fixed to legacy documentation:
1. PlaygroundLogger/Documentation/LoggerAPI.md -> Legacy/PlaygroundLogger/Documentation/LoggerAPI.md
2. PlaygroundLogger/Documentation/LoggerFormat.md -> Legacy/PlaygroundLogger/Documentation/LoggerFormat.md