### PR TITLE
Adopt the underscored variants of PlaygroundQuickLook, CustomPlaygrou…

### DIFF
--- a/PlaygroundLogger/PlaygroundLogger/LegacySupport/PlaygroundQuickLook+OpaqueRepresentationSupport.swift
+++ b/PlaygroundLogger/PlaygroundLogger/LegacySupport/PlaygroundQuickLook+OpaqueRepresentationSupport.swift
@@ -18,7 +18,7 @@ import Foundation
     import AppKit
 #endif
 
-extension PlaygroundQuickLook {
+extension _PlaygroundQuickLook {
     func opaqueRepresentation() throws -> LogEntry.OpaqueRepresentation {
         // TODO: don't crash in this function; instead, throw an error so we can encode an error log message instead
         

--- a/PlaygroundLogger/PlaygroundLogger/LogEntry+Reflection.swift
+++ b/PlaygroundLogger/PlaygroundLogger/LogEntry+Reflection.swift
@@ -93,10 +93,10 @@ extension LogEntry {
         }
         
         // For types which conform to the legacy `CustomPlaygroundQuickLookable` or `_DefaultCustomPlaygroundQuickLookable` protocols, get their `PlaygroundQuickLook` and use that for logging.
-        else if let customQuickLookable = instance as? CustomPlaygroundQuickLookable {
+        else if let customQuickLookable = instance as? _CustomPlaygroundQuickLookable {
             self = try .init(playgroundQuickLook: customQuickLookable.customPlaygroundQuickLook, name: name, typeName: typeName, summary: generateSummary(for: instance, withTypeName: typeName, using: mirror))
         }
-        else if let defaultQuickLookable = instance as? _DefaultCustomPlaygroundQuickLookable {
+        else if let defaultQuickLookable = instance as? __DefaultCustomPlaygroundQuickLookable {
             self = try .init(playgroundQuickLook: defaultQuickLookable._defaultCustomPlaygroundQuickLook, name: name, typeName: typeName, summary: generateSummary(for: instance, withTypeName: typeName, using: mirror))
         }
             
@@ -130,7 +130,7 @@ extension LogEntry {
         }
     }
     
-    private init(playgroundQuickLook: PlaygroundQuickLook, name: String, typeName: String, summary: String) throws {
+    private init(playgroundQuickLook: _PlaygroundQuickLook, name: String, typeName: String, summary: String) throws {
         // TODO: figure out when to set `preferBriefSummary` to true
         self = try .opaque(name: name, typeName: typeName, summary: summary, preferBriefSummary: false, representation: playgroundQuickLook.opaqueRepresentation())
     }

--- a/PlaygroundLogger/PlaygroundLoggerTests/LegacyPlaygroundLoggerTests.swift
+++ b/PlaygroundLogger/PlaygroundLoggerTests/LegacyPlaygroundLoggerTests.swift
@@ -640,12 +640,12 @@ class LegacyPlaygroundLoggerTests: XCTestCase {
     }
     
     func testPlaygroundQuickLookCalledOnce() {
-        class MyObject : CustomPlaygroundQuickLookable {
+        class MyObject : _CustomPlaygroundQuickLookable {
             var numCalls = 0
-            var customPlaygroundQuickLook: PlaygroundQuickLook {
+            var customPlaygroundQuickLook: _PlaygroundQuickLook {
                 get {
                     numCalls = numCalls + 1
-                    return PlaygroundQuickLook(reflecting: "Hello world")
+                    return .text("Hello world")
                 }
             }
         }


### PR DESCRIPTION
…ndQuickLookable, and _DefaultCustomPlaygroundQuickLookable.

The non-underscored variants are deprecated, but PlaygroundLogger needs to use these types as part of its implementation.
The underscored variants exist without deprecations so code which truly needs them (i.e. the standard library and PlaygroundLogger) can use them without warnings.

This addresses <rdar://problem/45287607>.