### PR TITLE
[PlaygroundLogger] Migrated PlaygroundLogger and its tests to Swift 5.

### DIFF
--- a/PlaygroundLogger/PlaygroundLogger.xcodeproj/project.pbxproj
+++ b/PlaygroundLogger/PlaygroundLogger.xcodeproj/project.pbxproj
@@ -818,7 +818,7 @@
 				TargetAttributes = {
 					5E2646261FB64876002DC6B6 = {
 						CreatedOnToolsVersion = 9.1;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1130;
 						ProvisioningStyle = Automatic;
 					};
 					5E26462F1FB64876002DC6B6 = {
@@ -834,12 +834,12 @@
 					};
 					5EFE9197203F6DD700E21BAA = {
 						CreatedOnToolsVersion = 9.3;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1130;
 						ProvisioningStyle = Automatic;
 					};
 					5EFE91AF203F6E8D00E21BAA = {
 						CreatedOnToolsVersion = 9.3;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1130;
 						ProvisioningStyle = Automatic;
 					};
 					5EFE91CC203F6F6900E21BAA = {
@@ -1177,7 +1177,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -1225,7 +1225,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/PlaygroundLogger/PlaygroundLogger/LogEntry+Reflection.swift
+++ b/PlaygroundLogger/PlaygroundLogger/LogEntry+Reflection.swift
@@ -172,6 +172,9 @@ extension LogEntry.StructuredDisposition {
             self = .keyContainer
         case .set:
             self = .membershipContainer
+        @unknown default:
+            // If this is an unknown display style, default to .container.
+            self = .container
         }
     }
 }
@@ -193,6 +196,9 @@ extension Mirror {
                 return policy.aggregateChildPolicy
             case .optional, .collection, .dictionary, .set:
                 return policy.containerChildPolicy
+            @unknown default:
+                // If this is an unknown display style, default to treating it like an aggregate.
+                return policy.aggregateChildPolicy
             }
         }()
 
@@ -204,6 +210,9 @@ extension Mirror {
                 // We don't want dictionary to count as a level of depth as dictionary is modeled as a collection of (key, value) pairs, and we don't want to lose a level due to the pairs themselves consuming a level, so for ease of bookkeeping the dictionary level is counted as not consuming a level.
                 return currentDepth
             case .class, .struct, .tuple, .enum, .collection, .set:
+                return currentDepth + 1
+            @unknown default:
+                // If this is an unknown display style, assume it consumes a level of depth.
                 return currentDepth + 1
             }
         }()

--- a/PlaygroundLogger/PlaygroundLoggerTests/LegacyPlaygroundLoggerTests.swift
+++ b/PlaygroundLogger/PlaygroundLoggerTests/LegacyPlaygroundLoggerTests.swift
@@ -830,6 +830,7 @@ enum PlaygroundRepresentation : UInt8, Hashable, CustomStringConvertible, Equata
         case .collection: self = .IndexContainer
         case .dictionary: self = .KeyContainer
         case .set: self = .MembershipContainer
+        @unknown default: self = .Container
         }
     }
 }


### PR DESCRIPTION
These were previously still building in Swift 4.2 mode.

This addresses <rdar://problem/59141771>.