### PR TITLE
[PlaygroundLogger] Set `SWIFT_INSTALL_OBJC_HEADER` to `NO`.

### DIFF
--- a/PlaygroundLogger/PlaygroundLogger.xcodeproj/project.pbxproj
+++ b/PlaygroundLogger/PlaygroundLogger.xcodeproj/project.pbxproj
@@ -1251,6 +1251,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = NO;
 				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos appletvsimulator appletvos";
+				SWIFT_INSTALL_OBJC_HEADER = NO;
 			};
 			name = Debug;
 		};
@@ -1272,6 +1273,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = NO;
 				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos appletvsimulator appletvos";
+				SWIFT_INSTALL_OBJC_HEADER = NO;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
The generated Objective-C header isn't used by PlaygroundLogger's clients, so this can safely be disabled.

This addresses <rdar://problem/72063883>.