### PR TITLE
[PlaygroundLogger] Added support for an environment variable which co…

### DIFF
--- a/PlaygroundLogger/PlaygroundLogger/LogPolicy.swift
+++ b/PlaygroundLogger/PlaygroundLogger/LogPolicy.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2018-2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -35,14 +35,23 @@ struct LogPolicy {
 
     /// Initializes a new `LogPolicy`.
     ///
-    /// - parameter maximumDepth: The maximum depth level for logging children of children. Defaults to 2.
+    /// - parameter maximumDepth: The maximum depth level for logging children of children. Defaults to 2, but the default can be overridden with the `LOGGER_DEPTH` environment variable.
     /// - parameter aggregateChildPolicy: The policy to use for logging children of aggregates. Defaults to logging no more than the first 10,000 children.
     /// - parameter containerChildPolicy: The policy to use for logging children of collections. Defaults to logging no more than the first 80 children plus the last 20 children.
-    init(maximumDepth: Int = 2,
+    init(maximumDepth: Int = (LogPolicy.environmentMaxDepth ?? 2),
          aggregateChildPolicy: ChildPolicy = .head(count: 10_000),
          containerChildPolicy: ChildPolicy = .headTail(headCount: 80, tailCount: 20)) {
         self.maximumDepth = maximumDepth
         self.aggregateChildPolicy = aggregateChildPolicy
         self.containerChildPolicy = containerChildPolicy
+    }
+    
+    /// Read and return the `LOGGER_DEPTH` from the environment.
+    static let loggerDepthEnvironmentKey = "LOGGER_DEPTH"
+    private static var environmentMaxDepth: Int? {
+        guard let envDepth = ProcessInfo.processInfo.environment[loggerDepthEnvironmentKey] else {
+            return nil
+        }
+        return Int(envDepth)
     }
 }

--- a/PlaygroundLogger/PlaygroundLoggerTests/LogPolicyTests.swift
+++ b/PlaygroundLogger/PlaygroundLoggerTests/LogPolicyTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2018-2021 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See http://swift.org/LICENSE.txt for license information
@@ -39,6 +39,14 @@ fileprivate class TestSubsubclass: TestSubclass {
 }
 
 class LogPolicyTests: XCTestCase {
+    func testMaximumDepthEnvironmentOverride() {
+        setenv("LOGGER_DEPTH", "4", 0)
+        let testPolicy = LogPolicy()
+        
+        XCTAssertEqual(testPolicy.maximumDepth, 4)
+        unsetenv("LOGGER_DEPTH")
+    }
+    
     func testMaximumDepthLimitZero() throws {
         let testPolicy = LogPolicy(maximumDepth: 0)
 


### PR DESCRIPTION
…ntrols the maximum depth of logging.

Logging previously unconditionally used a maximum depth of 2 when using one of the regular entry points (because logging would use the default policy).
This commit allows clients to set `LOGGER_DEPTH` in the environment when launching the process performing logging; if this is set to a valid integer, it will override the default depth of 2.

This addresses <rdar://problem/67252287>.